### PR TITLE
ci: remove windows tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
         os:
           - macOS-latest
           - ubuntu-latest
-          - windows-latest
         node-version:
           - 10
           - 12


### PR DESCRIPTION
The are failing due to an error that we can't control right now.