### PR TITLE
feat!: per-category formatter selection + eslint formatting backend

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,6 +29,8 @@ rsEslint(options) → assembleConfigs(options) → [...baseConfigs, ...featureCo
 2. **Feature configs** (conditional): sonar, typescript, stylistic, functional, vue, react, test, json, yaml, toml, markdown, formatters, etc.
 3. **Overrides**: User-provided rule overrides applied last
 
+Formatter categories are resolved **once** per assembly via `resolveFormatterCategories()` (`src/configs/formatters.ts`); both `formatters()` and the stylistic item consume that single resolution. When the `"eslint"` backend owns both `js` and `ts`, assembly restricts the stylistic item to the files the backend does not cover (`ignores` on js/jsx/ts/tsx globs) instead of dropping it — vue SFCs and markdown code blocks keep their coverage.
+
 ### Plugin Renaming System
 
 The config renames plugins for shorter rule prefixes:
@@ -112,6 +114,8 @@ The `mode` option controls strictness levels across multiple configs. It affects
 The `stylistic` option controls formatting/style rules across many configs. It's passed to: `imports`, `stylistic`, `vue`, `react`, `tailwind`, `unocss`, `json`, `yaml`, `toml`, `markdown`, `formatters`.
 
 When `stylistic: false`, formatting rules are disabled across all these configs. When adding a new config that has formatting rules, accept and respect this option.
+
+**Shared rule source:** `src/configs/stylistic.ts` and the `"eslint"` formatter backend (`src/configs/eslint-formatter.ts`) both build their `@stylistic/*` maps from one builder — `buildStylisticRules()` in `src/configs/stylistic-rules.ts`. Divergences between the two profiles are expressed only through that builder's explicit profile knobs; do not hand-edit one side's rule entries.
 
 ## Development Commands
 
@@ -204,6 +208,7 @@ Common types: `feat`, `fix`, `refactor`, `chore`, `docs`, `test`.
 7. **Config consolidation**: Small always-on configs are merged into related configs to reduce file count:
    - `sort.ts` → `jsonc.ts`: tsconfig sorting (`jsonc/sort-keys`) requires jsonc parser, always runs when jsonc enabled. Gated on `typescript && stylistic !== false`.
    - `comments.ts` → `javascript.ts`: eslint-comments plugin is always-on with zero user options, core JS concern.
+8. **ESLint formatting backend**: The `js`/`ts` formatter categories accept `"eslint"`, emitting pure `@stylistic/*` rules that approximate prettier style (no reflow, no line-length enforcement, violations are errors). Selecting it implies the style defaults: with `stylistic: false` the backend alone defines JS/TS style; with `stylistic` enabled the standalone stylistic item keeps covering only the files the backend does not own (vue SFCs, markdown code blocks, uncovered dts).
 
 ## Common Patterns
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Each category options object supports `formatter`, `prettierOptions`,
 `dprintOptions`, and `dprintPlugins`. Categories without an explicit `formatter`
 inherit the top-level `formatter` (default `"prettier"`).
 
+### CSS in Vue SFCs
+
+Style blocks inside Vue SFCs are formatted when both Vue support and the
+`css` category are active (`vue.sfcBlocks` defaults to enabled). The supported
+languages are `css`, `pcss`, `postcss`, `scss`, and `less`; style blocks in
+other languages are skipped.
+
 ### Migrating from the single global formatter
 
 Previously the formatter was chosen once globally, via a discriminated union on

--- a/README.md
+++ b/README.md
@@ -75,7 +75,9 @@ inherit the top-level `formatter` (default `"prettier"`).
 Style blocks inside Vue SFCs are formatted when both Vue support and the
 `css` category are active (`vue.sfcBlocks` defaults to enabled). The supported
 languages are `css`, `pcss`, `postcss`, `scss`, and `less`; style blocks in
-other languages are skipped.
+other languages are skipped. The matching globs target the processor's virtual
+output; a real on-disk path literally named like `*.vue/style.css` would also
+match — pathological and accepted, as formatter rules are harmless there.
 
 ### Migrating from the single global formatter
 

--- a/README.md
+++ b/README.md
@@ -52,3 +52,61 @@ export default rsEslint(
 ```
 
 See [ESLint configuration](https://eslint.org/docs/user-guide/configuring) for more information.
+
+## Formatters
+
+The `formatters` option enables formatting via `eslint-plugin-format`. Pass `true`
+to enable every category, or an object to configure each file category
+independently:
+
+| Category                          | Accepts                                                                          |
+| --------------------------------- | -------------------------------------------------------------------------------- |
+| `js`, `ts`                        | `true`, `false`, `"prettier"`, `"dprint"`, `"eslint"`, or an options object       |
+| `json`, `yaml`, `css`, `html`, `markdown`, `graphql` | `true`, `false`, `"prettier"`, `"dprint"`, or an options object |
+| `dts`, `tailwind`                 | `boolean`                                                                        |
+| `slidev`                          | `boolean` or `{ files?, formatter?, prettierOptions?, dprintOptions?, dprintPlugins? }` |
+
+Each category options object supports `formatter`, `prettierOptions`,
+`dprintOptions`, and `dprintPlugins`. Categories without an explicit `formatter`
+inherit the top-level `formatter` (default `"prettier"`).
+
+### Migrating from the single global formatter
+
+Previously the formatter was chosen once globally, via a discriminated union on
+`formatter: "prettier" | "dprint"`:
+
+```js
+// Before: one formatter for everything; dprintPlugins was top-level only.
+export default rsEslint({
+  formatters: {
+    formatter: "dprint",
+    dprintOptions: { lineWidth: 100 },
+    dprintPlugins: ["@dprint/typescript"],
+    ts: false,
+  },
+});
+```
+
+```js
+// After: per-category selection; dprintPlugins is per-category.
+export default rsEslint({
+  formatters: {
+    formatter: "dprint", // top-level default (unchanged)
+    dprintOptions: { lineWidth: 100 }, // top-level default (unchanged)
+    js: { dprintPlugins: ["@dprint/typescript"] },
+    ts: false,
+  },
+});
+```
+
+Mapping:
+
+- Top-level `formatter: "prettier"` with `prettierOptions` → unchanged.
+- Top-level `formatter: "dprint"` with `dprintOptions` → unchanged.
+- Top-level `dprintPlugins` → removed. Move it into each category that should
+  use dprint (e.g. `js: { dprintPlugins: [...] }`).
+- Per-category booleans (`ts: false`, ...) → unchanged.
+- New: per-category `prettierOptions`/`dprintOptions` overrides merged over
+  the top-level ones.
+- Upcoming: `"eslint"` backend for `js`/`ts` (landing in the next release
+  commit — currently falls back to prettier).

--- a/README.md
+++ b/README.md
@@ -59,12 +59,12 @@ The `formatters` option enables formatting via `eslint-plugin-format`. Pass `tru
 to enable every category, or an object to configure each file category
 independently:
 
-| Category                          | Accepts                                                                          |
-| --------------------------------- | -------------------------------------------------------------------------------- |
-| `js`, `ts`                        | `true`, `false`, `"prettier"`, `"dprint"`, `"eslint"`, or an options object       |
-| `json`, `yaml`, `css`, `html`, `markdown`, `graphql` | `true`, `false`, `"prettier"`, `"dprint"`, or an options object |
-| `dts`, `tailwind`                 | `boolean`                                                                        |
-| `slidev`                          | `boolean` or `{ files?, formatter?, prettierOptions?, dprintOptions?, dprintPlugins? }` |
+| Category                                             | Accepts                                                                                 |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `js`, `ts`                                           | `true`, `false`, `"prettier"`, `"dprint"`, `"eslint"`, or an options object             |
+| `json`, `yaml`, `css`, `html`, `markdown`, `graphql` | `true`, `false`, `"prettier"`, `"dprint"`, or an options object                         |
+| `dts`, `tailwind`                                    | `boolean`                                                                               |
+| `slidev`                                             | `boolean` or `{ files?, formatter?, prettierOptions?, dprintOptions?, dprintPlugins? }` |
 
 Each category options object supports `formatter`, `prettierOptions`,
 `dprintOptions`, and `dprintPlugins`. Categories without an explicit `formatter`
@@ -108,5 +108,39 @@ Mapping:
 - Per-category booleans (`ts: false`, ...) → unchanged.
 - New: per-category `prettierOptions`/`dprintOptions` overrides merged over
   the top-level ones.
-- Upcoming: `"eslint"` backend for `js`/`ts` (landing in the next release
-  commit — currently falls back to prettier).
+- New: `"eslint"` backend for `js`/`ts` — see below.
+
+### The `"eslint"` backend for `js` and `ts`
+
+The `js` and `ts` categories can skip external formatters entirely and use
+pure `@stylistic/*` rules instead:
+
+```js
+export default rsEslint({
+  formatters: {
+    js: "eslint",
+    ts: "eslint",
+  },
+});
+```
+
+This backend **approximates** prettier's style — it does not replicate it:
+
+- **No reflow.** No line-length rule is enabled (`max-len` stays off), so long
+  lines stay long instead of being wrapped.
+- **Nested ternaries are not force-broken.** `multiline-ternary` is set to
+  `"always-multiline"`; no available rule expresses prettier's nested-ternary
+  breaking (documented gap).
+- Relaxed by design: chain-break forcing (`newline-per-chained-call`) and
+  `max-statements-per-line` are disabled, `object-curly-newline` only requires
+  consistency, and trailing commas follow `comma-dangle: "only-multiline"`.
+- Indentation is enforced for TypeScript code too (`@stylistic/indent` with
+  TS-aware offsets), unlike the default stylistic profile where prettier owns it.
+- Violations are reported as lint errors rather than silently reformatted.
+
+Tailwind class sorting is unaffected:
+`tailwind-better/enforce-consistent-class-order` stays active without any
+prettier plugins.
+
+In editors the backend remains active — the in-editor configuration disables no
+`@stylistic/*` rules.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Each category options object supports `formatter`, `prettierOptions`,
 `dprintOptions`, and `dprintPlugins`. Categories without an explicit `formatter`
 inherit the top-level `formatter` (default `"prettier"`).
 
+Indented `.sass` files are not formatted (neither prettier nor dprint supports
+the indented syntax) — use `.scss` instead.
+
 ### CSS in Vue SFCs
 
 Style blocks inside Vue SFCs are formatted when both Vue support and the

--- a/README.md
+++ b/README.md
@@ -156,3 +156,13 @@ the standalone `stylistic` option stops applying to those files:
 - With `stylistic: false`, the backend alone defines JS/TS style: the formatter
   implies the style defaults, so you get the relaxed profile above with no
   further configuration.
+
+### Deferred to @stylistic v6
+
+Several configured rules (`array-bracket-newline`, `array-bracket-spacing`,
+`array-element-newline`, `function-call-argument-newline`,
+`function-paren-newline`, `object-curly-newline`, `object-curly-spacing`,
+`object-property-newline`) are deprecated in `@stylistic@5` in favor of the
+unified [`list-style`](https://eslint.style/rules/list-style) rule, which only
+becomes stable in `@stylistic@6`. Migration to `list-style` is deferred until
+that release; these rules keep their current configuration in the meantime.

--- a/README.md
+++ b/README.md
@@ -144,3 +144,15 @@ prettier plugins.
 
 In editors the backend remains active — the in-editor configuration disables no
 `@stylistic/*` rules.
+
+### Semantics: selecting the backend implies style defaults
+
+When `js` or `ts` selects `"eslint"`, that category owns JS/TS formatting, and
+the standalone `stylistic` option stops applying to those files:
+
+- With `stylistic` enabled (the default), its rules stay active everywhere the
+  backend does not reach — Vue SFCs, markdown code blocks, and declaration
+  files when `formatters.dts` is unset.
+- With `stylistic: false`, the backend alone defines JS/TS style: the formatter
+  implies the style defaults, so you get the relaxed profile above with no
+  further configuration.

--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ inherit the top-level `formatter` (default `"prettier"`).
 Indented `.sass` files are not formatted (neither prettier nor dprint supports
 the indented syntax) — use `.scss` instead.
 
+Dedicated formatter categories for XML, SQL, shell scripts, CSV, and Dockerfile
+are plausible future additions — each needs parser or plugin wiring — but none
+is currently planned.
+
 ### CSS in Vue SFCs
 
 Style blocks inside Vue SFCs are formatted when both Vue support and the

--- a/docs/rule-audit.md
+++ b/docs/rule-audit.md
@@ -32,495 +32,495 @@ each disablement so the next engineer inherits reasons, not folklore.
 
 ## Summary matrix
 
-| File | static | Total |
-|---|---|---|
-| ``no-irregular-whitespace`` | 2 | 2 |
-| ``yml/block-sequence-hyphen-indicator-newline`` | 1 | 1 |
-| ``no-unexpected-multiline`` | 1 | 1 |
-| ``@stylistic/max-len`` | 1 | 1 |
-| ``@stylistic/no-confusing-arrow`` | 1 | 1 |
-| ``@stylistic/no-mixed-operators`` | 1 | 1 |
-| ``@stylistic/no-tabs`` | 1 | 1 |
-| ``@stylistic/quotes`` | 1 | 1 |
-| ``@stylistic/js/no-confusing-arrow`` | 1 | 1 |
-| ``@stylistic/js/no-mixed-operators`` | 1 | 1 |
-| ``@stylistic/js/no-tabs`` | 1 | 1 |
-| ``@stylistic/js/quotes`` | 1 | 1 |
-| ``@stylistic/ts/quotes`` | 1 | 1 |
-| ``@typescript-eslint/lines-around-comment`` | 1 | 1 |
-| ``@typescript-eslint/quotes`` | 1 | 1 |
-| ``vue/html-self-closing`` | 1 | 1 |
-| ``vue/max-len`` | 1 | 1 |
-| ``@stylistic/operator-linebreak`` | 1 | 1 |
-| ``unicorn/no-nested-ternary`` | 1 | 1 |
-| ``import-x/order`` | 2 | 2 |
-| ``sort-imports`` | 1 | 1 |
-| ``embeddedLanguageFormatting`` | 2 | 2 |
-| ``@typescript-eslint/prefer-readonly-parameter-types`` | 1 | 1 |
-| ``functional/no-conditional-statements`` | 2 | 2 |
-| ``functional/no-expression-statements`` | 2 | 2 |
-| ``functional/no-return-void`` | 2 | 2 |
-| ``import-x/no-unresolved`` | 3 | 3 |
-| ``import-x/named`` | 3 | 3 |
-| ``import-x/default`` | 2 | 2 |
-| ``import-x/namespace`` | 2 | 2 |
-| ``dot-notation`` | 2 | 2 |
-| ``init-declarations`` | 1 | 1 |
-| ``no-alert`` | 1 | 1 |
-| ``no-console`` | 2 | 2 |
-| ``no-empty-function`` | 1 | 1 |
-| ``no-empty`` | 1 | 1 |
-| ``no-invalid-this`` | 2 | 2 |
-| ``no-labels`` | 1 | 1 |
-| ``no-lone-blocks`` | 1 | 1 |
-| ``no-restricted-syntax`` | 2 | 2 |
-| ``no-throw-literal`` | 2 | 2 |
-| ``no-undef`` | 2 | 2 |
-| ``no-unused-expressions`` | 1 | 1 |
-| ``no-unused-labels`` | 1 | 1 |
-| ``no-unused-vars`` | 2 | 2 |
-| ``no-useless-return`` | 1 | 1 |
-| ``prefer-const`` | 1 | 1 |
-| ``unicode-bom`` | 1 | 1 |
-| ``import-x/extensions`` | 1 | 1 |
-| ``import-x/newline-after-import`` | 1 | 1 |
-| ``import-x/no-extraneous-dependencies`` | 1 | 1 |
-| ``jsdoc/require-jsdoc`` | 3 | 3 |
-| ``n/handle-callback-err`` | 1 | 1 |
-| ``n/prefer-global/process`` | 3 | 3 |
-| ``prettier/prettier`` | 1 | 1 |
-| ``sonarjs/no-extra-arguments`` | 1 | 1 |
-| ``sonarjs/no-unused-collection`` | 1 | 1 |
-| ``@stylistic/comma-dangle`` | 1 | 1 |
-| ``@stylistic/eol-last`` | 1 | 1 |
-| ``@typescript-eslint/consistent-generic-constructors`` | 1 | 1 |
-| ``@typescript-eslint/consistent-indexed-object-style`` | 1 | 1 |
-| ``@typescript-eslint/consistent-type-definitions`` | 4 | 4 |
-| ``@typescript-eslint/consistent-type-imports`` | 1 | 1 |
-| ``@typescript-eslint/explicit-member-accessibility`` | 1 | 1 |
-| ``@typescript-eslint/naming-convention`` | 1 | 1 |
-| ``@typescript-eslint/no-empty-function`` | 1 | 1 |
-| ``@typescript-eslint/no-explicit-any`` | 2 | 2 |
-| ``@typescript-eslint/no-namespace`` | 1 | 1 |
-| ``@typescript-eslint/no-redeclare`` | 2 | 2 |
-| ``@typescript-eslint/no-require-imports`` | 2 | 2 |
-| ``@typescript-eslint/no-unused-expressions`` | 2 | 2 |
-| ``@typescript-eslint/no-unused-vars`` | 3 | 3 |
-| ``@typescript-eslint/no-use-before-define`` | 1 | 1 |
-| ``@typescript-eslint/prefer-for-of`` | 1 | 1 |
-| ``@typescript-eslint/prefer-function-type`` | 1 | 1 |
-| ``unicorn/prefer-optional-catch-binding`` | 1 | 1 |
-| ``unicorn/prefer-top-level-await`` | 1 | 1 |
-| ``unicorn/prefer-type-literal-last`` | 1 | 1 |
-| ``unicorn/switch-case-braces`` | 1 | 1 |
-| ``n/global-require`` | 1 | 1 |
-| ``n/no-missing-import`` | 1 | 1 |
-| ``n/no-unsupported-features/es-syntax`` | 1 | 1 |
-| ``n/no-extraneous-import`` | 1 | 1 |
-| ``n/no-restricted-import`` | 1 | 1 |
-| ``n/no-restricted-require`` | 1 | 1 |
-| ``comments/no-unlimited-disable`` | 1 | 1 |
-| ``import-x/no-duplicates`` | 1 | 1 |
-| ``import-x/no-unassigned-import`` | 1 | 1 |
-| ``jsdoc/check-examples`` | 1 | 1 |
-| ``jsdoc/check-indentation`` | 1 | 1 |
-| ``jsdoc/check-line-alignment`` | 1 | 1 |
-| ``jsdoc/check-param-names`` | 1 | 1 |
-| ``jsdoc/check-property-names`` | 1 | 1 |
-| ``jsdoc/check-types`` | 1 | 1 |
-| ``jsdoc/check-values`` | 1 | 1 |
-| ``jsdoc/no-bad-blocks`` | 1 | 1 |
-| ``jsdoc/no-defaults`` | 1 | 1 |
-| ``jsdoc/require-asterisk-prefix`` | 1 | 1 |
-| ``jsdoc/require-description`` | 1 | 1 |
-| ``jsdoc/require-description-complete-sentence`` | 1 | 1 |
-| ``jsdoc/require-hyphen-before-param-description`` | 1 | 1 |
-| ``jsdoc/require-param-name`` | 1 | 1 |
-| ``jsdoc/require-param`` | 1 | 1 |
-| ``jsdoc/require-property-name`` | 1 | 1 |
-| ``jsdoc/require-property`` | 1 | 1 |
-| ``jsdoc/require-returns-check`` | 1 | 1 |
-| ``jsdoc/require-returns`` | 1 | 1 |
-| ``jsdoc/require-throws`` | 1 | 1 |
-| ``jsdoc/require-yields-check`` | 1 | 1 |
-| ``jsdoc/tag-lines`` | 1 | 1 |
-| ``jsdoc/check-access`` | 1 | 1 |
-| ``jsdoc/empty-tags`` | 1 | 1 |
-| ``jsdoc/implements-on-classes`` | 1 | 1 |
-| ``jsdoc/no-multi-asterisks`` | 1 | 1 |
-| ``jsdoc/require-property-description`` | 1 | 1 |
-| ``jsdoc/require-returns-description`` | 1 | 1 |
-| ``jsdoc/check-alignment`` | 1 | 1 |
-| ``jsdoc/multiline-blocks`` | 1 | 1 |
-| ``@typescript-eslint/no-empty-object-type`` | 1 | 1 |
-| ``unicorn/filename-case`` | 1 | 1 |
-| ``functional/no-loop-statements`` | 1 | 1 |
-| ``functional/no-throw-statements`` | 1 | 1 |
-| ``n/no-sync`` | 2 | 2 |
-| ``n/no-unpublished-import`` | 1 | 1 |
-| ``perfectionist/sort-objects`` | 1 | 1 |
-| ``perfectionist/sort-classes`` | 1 | 1 |
-| ``perfectionist/sort-interfaces`` | 1 | 1 |
-| ``perfectionist/sort-jsx-props`` | 1 | 1 |
-| ``perfectionist/sort-enums`` | 1 | 1 |
-| ``perfectionist/sort-sets`` | 1 | 1 |
-| ``perfectionist/sort-maps`` | 1 | 1 |
-| ``perfectionist/sort-array-includes`` | 1 | 1 |
-| ``import/order`` | 1 | 1 |
-| ``jsx-a11y/label-has-for`` | 1 | 1 |
-| ``no-empty-character-class`` | 1 | 1 |
-| ``no-invalid-regexp`` | 1 | 1 |
-| ``no-useless-backreference`` | 1 | 1 |
-| ``security/detect-unsafe-regex`` | 1 | 1 |
-| ``security/detect-non-literal-fs-filename`` | 1 | 1 |
-| ``security/detect-non-literal-regexp`` | 1 | 1 |
-| ``security/detect-object-injection`` | 1 | 1 |
-| ``sonarjs/argument-type`` | 1 | 1 |
-| ``sonarjs/assertions-in-tests`` | 1 | 1 |
-| ``sonarjs/no-default-utility-imports`` | 1 | 1 |
-| ``sonarjs/no-unused-vars`` | 1 | 1 |
-| ``sonarjs/no-fallthrough`` | 1 | 1 |
-| ``sonarjs/no-labels`` | 1 | 1 |
-| ``sonarjs/code-eval`` | 1 | 1 |
-| ``sonarjs/no-parameter-reassignment`` | 1 | 1 |
-| ``sonarjs/no-nested-conditional`` | 1 | 1 |
-| ``sonarjs/cognitive-complexity`` | 1 | 1 |
-| ``sonarjs/todo-tag`` | 1 | 1 |
-| ``sonarjs/redundant-type-aliases`` | 1 | 1 |
-| ``sonarjs/function-return-type`` | 1 | 1 |
-| ``sonarjs/deprecation`` | 1 | 1 |
-| ``sonarjs/different-types-comparison`` | 1 | 1 |
-| ``sonarjs/no-alphabetical-sort`` | 1 | 1 |
-| ``sonarjs/use-type-alias`` | 1 | 1 |
-| ``sonarjs/void-use`` | 1 | 1 |
-| ``tailwind-better/enforce-consistent-important-position`` | 1 | 1 |
-| ``tailwind-better/enforce-shorthand-classes`` | 1 | 1 |
-| ``import-x/no-named-as-default-member`` | 1 | 1 |
-| ``regexp/no-super-linear-backtracking`` | 1 | 1 |
-| ``sonarjs/no-duplicate-string`` | 1 | 1 |
-| ``sonarjs/no-identical-functions`` | 1 | 1 |
-| ``vitest/valid-expect`` | 1 | 1 |
-| ``@typescript-eslint/no-unsafe-argument`` | 1 | 1 |
-| ``@typescript-eslint/no-unsafe-assignment`` | 1 | 1 |
-| ``@typescript-eslint/no-unsafe-call`` | 1 | 1 |
-| ``@typescript-eslint/no-unsafe-member-access`` | 1 | 1 |
-| ``@typescript-eslint/no-unsafe-return`` | 1 | 1 |
-| ``@typescript-eslint/strict-boolean-expressions`` | 1 | 1 |
-| ``unicorn/consistent-function-scoping`` | 1 | 1 |
-| ``unicorn/prefer-module`` | 2 | 2 |
-| ``@stylistic/spaced-comment`` | 2 | 2 |
-| ``no-extra-boolean-cast`` | 1 | 1 |
-| ``consistent-return`` | 1 | 1 |
-| ``@typescript-eslint/no-unsafe-type-assertion`` | 1 | 1 |
-| ``no-loop-func`` | 1 | 1 |
-| ``no-use-before-define`` | 1 | 1 |
-| ``no-shadow`` | 1 | 1 |
-| ``no-dupe-class-members`` | 1 | 1 |
-| ``@typescript-eslint/no-dupe-class-members`` | 1 | 1 |
-| ``@typescript-eslint/no-invalid-this`` | 1 | 1 |
-| ``no-redeclare`` | 1 | 1 |
-| ``class-methods-use-this`` | 1 | 1 |
-| ``no-array-constructor`` | 1 | 1 |
-| ``no-implied-eval`` | 1 | 1 |
-| ``no-return-await`` | 1 | 1 |
-| ``no-useless-constructor`` | 1 | 1 |
-| ``prefer-destructuring`` | 1 | 1 |
-| ``prefer-promise-reject-errors`` | 1 | 1 |
-| ``require-await`` | 1 | 1 |
-| ``@typescript-eslint/triple-slash-reference`` | 1 | 1 |
-| ``@typescript-eslint/ban-ts-comment`` | 1 | 1 |
-| ``@typescript-eslint/no-var-requires`` | 1 | 1 |
-| ``unicorn/no-anonymous-default-export`` | 1 | 1 |
-| ``unicorn/no-await-in-promise-methods`` | 1 | 1 |
-| ``unicorn/no-single-promise-in-promise-methods`` | 1 | 1 |
-| ``unicorn/no-useless-spread`` | 1 | 1 |
-| ``unicorn/name-replacements`` | 1 | 1 |
-| ``unicorn/no-non-function-verb-prefix`` | 1 | 1 |
-| ``unicorn/no-null`` | 1 | 1 |
-| ``unicorn/no-top-level-side-effects`` | 1 | 1 |
-| ``unicorn/no-unsafe-property-key`` | 1 | 1 |
-| ``unicorn/no-useless-undefined`` | 1 | 1 |
-| ``unicorn/prefer-await`` | 1 | 1 |
-| ``unicorn/prefer-string-raw`` | 1 | 1 |
-| ``unicorn/single-line-block-comment-style`` | 1 | 1 |
-| ``unicorn/consistent-boolean-name`` | 1 | 1 |
-| ``unicorn/consistent-conditional-object-spread`` | 1 | 1 |
-| ``unicorn/no-array-callback-reference`` | 1 | 1 |
-| ``unicorn/no-array-reduce`` | 1 | 1 |
-| ``unicorn/no-break-in-nested-loop`` | 1 | 1 |
-| ``unicorn/no-computed-property-existence-check`` | 1 | 1 |
-| ``unicorn/no-top-level-assignment-in-function`` | 1 | 1 |
-| ``unicorn/no-unreadable-array-destructuring`` | 1 | 1 |
-| ``unicorn/prefer-promise-with-resolvers`` | 1 | 1 |
-| ``unicorn/prevent-abbreviations`` | 1 | 1 |
-| ``unicorn/prefer-iterator-helpers`` | 1 | 1 |
-| ``unicorn/prefer-iterator-to-array`` | 1 | 1 |
-| ``unicorn/prefer-set-methods`` | 1 | 1 |
-| ``vue/multi-word-component-names`` | 1 | 1 |
-| **Total** | 258 | 258 |
+| File                                                    | static | Total |
+| ------------------------------------------------------- | ------ | ----- |
+| `no-irregular-whitespace`                               | 2      | 2     |
+| `yml/block-sequence-hyphen-indicator-newline`           | 1      | 1     |
+| `no-unexpected-multiline`                               | 1      | 1     |
+| `@stylistic/max-len`                                    | 1      | 1     |
+| `@stylistic/no-confusing-arrow`                         | 1      | 1     |
+| `@stylistic/no-mixed-operators`                         | 1      | 1     |
+| `@stylistic/no-tabs`                                    | 1      | 1     |
+| `@stylistic/quotes`                                     | 1      | 1     |
+| `@stylistic/js/no-confusing-arrow`                      | 1      | 1     |
+| `@stylistic/js/no-mixed-operators`                      | 1      | 1     |
+| `@stylistic/js/no-tabs`                                 | 1      | 1     |
+| `@stylistic/js/quotes`                                  | 1      | 1     |
+| `@stylistic/ts/quotes`                                  | 1      | 1     |
+| `@typescript-eslint/lines-around-comment`               | 1      | 1     |
+| `@typescript-eslint/quotes`                             | 1      | 1     |
+| `vue/html-self-closing`                                 | 1      | 1     |
+| `vue/max-len`                                           | 1      | 1     |
+| `@stylistic/operator-linebreak`                         | 1      | 1     |
+| `unicorn/no-nested-ternary`                             | 1      | 1     |
+| `import-x/order`                                        | 2      | 2     |
+| `sort-imports`                                          | 1      | 1     |
+| `embeddedLanguageFormatting`                            | 2      | 2     |
+| `@typescript-eslint/prefer-readonly-parameter-types`    | 1      | 1     |
+| `functional/no-conditional-statements`                  | 2      | 2     |
+| `functional/no-expression-statements`                   | 2      | 2     |
+| `functional/no-return-void`                             | 2      | 2     |
+| `import-x/no-unresolved`                                | 3      | 3     |
+| `import-x/named`                                        | 3      | 3     |
+| `import-x/default`                                      | 2      | 2     |
+| `import-x/namespace`                                    | 2      | 2     |
+| `dot-notation`                                          | 2      | 2     |
+| `init-declarations`                                     | 1      | 1     |
+| `no-alert`                                              | 1      | 1     |
+| `no-console`                                            | 2      | 2     |
+| `no-empty-function`                                     | 1      | 1     |
+| `no-empty`                                              | 1      | 1     |
+| `no-invalid-this`                                       | 2      | 2     |
+| `no-labels`                                             | 1      | 1     |
+| `no-lone-blocks`                                        | 1      | 1     |
+| `no-restricted-syntax`                                  | 2      | 2     |
+| `no-throw-literal`                                      | 2      | 2     |
+| `no-undef`                                              | 2      | 2     |
+| `no-unused-expressions`                                 | 1      | 1     |
+| `no-unused-labels`                                      | 1      | 1     |
+| `no-unused-vars`                                        | 2      | 2     |
+| `no-useless-return`                                     | 1      | 1     |
+| `prefer-const`                                          | 1      | 1     |
+| `unicode-bom`                                           | 1      | 1     |
+| `import-x/extensions`                                   | 1      | 1     |
+| `import-x/newline-after-import`                         | 1      | 1     |
+| `import-x/no-extraneous-dependencies`                   | 1      | 1     |
+| `jsdoc/require-jsdoc`                                   | 3      | 3     |
+| `n/handle-callback-err`                                 | 1      | 1     |
+| `n/prefer-global/process`                               | 3      | 3     |
+| `prettier/prettier`                                     | 1      | 1     |
+| `sonarjs/no-extra-arguments`                            | 1      | 1     |
+| `sonarjs/no-unused-collection`                          | 1      | 1     |
+| `@stylistic/comma-dangle`                               | 1      | 1     |
+| `@stylistic/eol-last`                                   | 1      | 1     |
+| `@typescript-eslint/consistent-generic-constructors`    | 1      | 1     |
+| `@typescript-eslint/consistent-indexed-object-style`    | 1      | 1     |
+| `@typescript-eslint/consistent-type-definitions`        | 4      | 4     |
+| `@typescript-eslint/consistent-type-imports`            | 1      | 1     |
+| `@typescript-eslint/explicit-member-accessibility`      | 1      | 1     |
+| `@typescript-eslint/naming-convention`                  | 1      | 1     |
+| `@typescript-eslint/no-empty-function`                  | 1      | 1     |
+| `@typescript-eslint/no-explicit-any`                    | 2      | 2     |
+| `@typescript-eslint/no-namespace`                       | 1      | 1     |
+| `@typescript-eslint/no-redeclare`                       | 2      | 2     |
+| `@typescript-eslint/no-require-imports`                 | 2      | 2     |
+| `@typescript-eslint/no-unused-expressions`              | 2      | 2     |
+| `@typescript-eslint/no-unused-vars`                     | 3      | 3     |
+| `@typescript-eslint/no-use-before-define`               | 1      | 1     |
+| `@typescript-eslint/prefer-for-of`                      | 1      | 1     |
+| `@typescript-eslint/prefer-function-type`               | 1      | 1     |
+| `unicorn/prefer-optional-catch-binding`                 | 1      | 1     |
+| `unicorn/prefer-top-level-await`                        | 1      | 1     |
+| `unicorn/prefer-type-literal-last`                      | 1      | 1     |
+| `unicorn/switch-case-braces`                            | 1      | 1     |
+| `n/global-require`                                      | 1      | 1     |
+| `n/no-missing-import`                                   | 1      | 1     |
+| `n/no-unsupported-features/es-syntax`                   | 1      | 1     |
+| `n/no-extraneous-import`                                | 1      | 1     |
+| `n/no-restricted-import`                                | 1      | 1     |
+| `n/no-restricted-require`                               | 1      | 1     |
+| `comments/no-unlimited-disable`                         | 1      | 1     |
+| `import-x/no-duplicates`                                | 1      | 1     |
+| `import-x/no-unassigned-import`                         | 1      | 1     |
+| `jsdoc/check-examples`                                  | 1      | 1     |
+| `jsdoc/check-indentation`                               | 1      | 1     |
+| `jsdoc/check-line-alignment`                            | 1      | 1     |
+| `jsdoc/check-param-names`                               | 1      | 1     |
+| `jsdoc/check-property-names`                            | 1      | 1     |
+| `jsdoc/check-types`                                     | 1      | 1     |
+| `jsdoc/check-values`                                    | 1      | 1     |
+| `jsdoc/no-bad-blocks`                                   | 1      | 1     |
+| `jsdoc/no-defaults`                                     | 1      | 1     |
+| `jsdoc/require-asterisk-prefix`                         | 1      | 1     |
+| `jsdoc/require-description`                             | 1      | 1     |
+| `jsdoc/require-description-complete-sentence`           | 1      | 1     |
+| `jsdoc/require-hyphen-before-param-description`         | 1      | 1     |
+| `jsdoc/require-param-name`                              | 1      | 1     |
+| `jsdoc/require-param`                                   | 1      | 1     |
+| `jsdoc/require-property-name`                           | 1      | 1     |
+| `jsdoc/require-property`                                | 1      | 1     |
+| `jsdoc/require-returns-check`                           | 1      | 1     |
+| `jsdoc/require-returns`                                 | 1      | 1     |
+| `jsdoc/require-throws`                                  | 1      | 1     |
+| `jsdoc/require-yields-check`                            | 1      | 1     |
+| `jsdoc/tag-lines`                                       | 1      | 1     |
+| `jsdoc/check-access`                                    | 1      | 1     |
+| `jsdoc/empty-tags`                                      | 1      | 1     |
+| `jsdoc/implements-on-classes`                           | 1      | 1     |
+| `jsdoc/no-multi-asterisks`                              | 1      | 1     |
+| `jsdoc/require-property-description`                    | 1      | 1     |
+| `jsdoc/require-returns-description`                     | 1      | 1     |
+| `jsdoc/check-alignment`                                 | 1      | 1     |
+| `jsdoc/multiline-blocks`                                | 1      | 1     |
+| `@typescript-eslint/no-empty-object-type`               | 1      | 1     |
+| `unicorn/filename-case`                                 | 1      | 1     |
+| `functional/no-loop-statements`                         | 1      | 1     |
+| `functional/no-throw-statements`                        | 1      | 1     |
+| `n/no-sync`                                             | 2      | 2     |
+| `n/no-unpublished-import`                               | 1      | 1     |
+| `perfectionist/sort-objects`                            | 1      | 1     |
+| `perfectionist/sort-classes`                            | 1      | 1     |
+| `perfectionist/sort-interfaces`                         | 1      | 1     |
+| `perfectionist/sort-jsx-props`                          | 1      | 1     |
+| `perfectionist/sort-enums`                              | 1      | 1     |
+| `perfectionist/sort-sets`                               | 1      | 1     |
+| `perfectionist/sort-maps`                               | 1      | 1     |
+| `perfectionist/sort-array-includes`                     | 1      | 1     |
+| `import/order`                                          | 1      | 1     |
+| `jsx-a11y/label-has-for`                                | 1      | 1     |
+| `no-empty-character-class`                              | 1      | 1     |
+| `no-invalid-regexp`                                     | 1      | 1     |
+| `no-useless-backreference`                              | 1      | 1     |
+| `security/detect-unsafe-regex`                          | 1      | 1     |
+| `security/detect-non-literal-fs-filename`               | 1      | 1     |
+| `security/detect-non-literal-regexp`                    | 1      | 1     |
+| `security/detect-object-injection`                      | 1      | 1     |
+| `sonarjs/argument-type`                                 | 1      | 1     |
+| `sonarjs/assertions-in-tests`                           | 1      | 1     |
+| `sonarjs/no-default-utility-imports`                    | 1      | 1     |
+| `sonarjs/no-unused-vars`                                | 1      | 1     |
+| `sonarjs/no-fallthrough`                                | 1      | 1     |
+| `sonarjs/no-labels`                                     | 1      | 1     |
+| `sonarjs/code-eval`                                     | 1      | 1     |
+| `sonarjs/no-parameter-reassignment`                     | 1      | 1     |
+| `sonarjs/no-nested-conditional`                         | 1      | 1     |
+| `sonarjs/cognitive-complexity`                          | 1      | 1     |
+| `sonarjs/todo-tag`                                      | 1      | 1     |
+| `sonarjs/redundant-type-aliases`                        | 1      | 1     |
+| `sonarjs/function-return-type`                          | 1      | 1     |
+| `sonarjs/deprecation`                                   | 1      | 1     |
+| `sonarjs/different-types-comparison`                    | 1      | 1     |
+| `sonarjs/no-alphabetical-sort`                          | 1      | 1     |
+| `sonarjs/use-type-alias`                                | 1      | 1     |
+| `sonarjs/void-use`                                      | 1      | 1     |
+| `tailwind-better/enforce-consistent-important-position` | 1      | 1     |
+| `tailwind-better/enforce-shorthand-classes`             | 1      | 1     |
+| `import-x/no-named-as-default-member`                   | 1      | 1     |
+| `regexp/no-super-linear-backtracking`                   | 1      | 1     |
+| `sonarjs/no-duplicate-string`                           | 1      | 1     |
+| `sonarjs/no-identical-functions`                        | 1      | 1     |
+| `vitest/valid-expect`                                   | 1      | 1     |
+| `@typescript-eslint/no-unsafe-argument`                 | 1      | 1     |
+| `@typescript-eslint/no-unsafe-assignment`               | 1      | 1     |
+| `@typescript-eslint/no-unsafe-call`                     | 1      | 1     |
+| `@typescript-eslint/no-unsafe-member-access`            | 1      | 1     |
+| `@typescript-eslint/no-unsafe-return`                   | 1      | 1     |
+| `@typescript-eslint/strict-boolean-expressions`         | 1      | 1     |
+| `unicorn/consistent-function-scoping`                   | 1      | 1     |
+| `unicorn/prefer-module`                                 | 2      | 2     |
+| `@stylistic/spaced-comment`                             | 2      | 2     |
+| `no-extra-boolean-cast`                                 | 1      | 1     |
+| `consistent-return`                                     | 1      | 1     |
+| `@typescript-eslint/no-unsafe-type-assertion`           | 1      | 1     |
+| `no-loop-func`                                          | 1      | 1     |
+| `no-use-before-define`                                  | 1      | 1     |
+| `no-shadow`                                             | 1      | 1     |
+| `no-dupe-class-members`                                 | 1      | 1     |
+| `@typescript-eslint/no-dupe-class-members`              | 1      | 1     |
+| `@typescript-eslint/no-invalid-this`                    | 1      | 1     |
+| `no-redeclare`                                          | 1      | 1     |
+| `class-methods-use-this`                                | 1      | 1     |
+| `no-array-constructor`                                  | 1      | 1     |
+| `no-implied-eval`                                       | 1      | 1     |
+| `no-return-await`                                       | 1      | 1     |
+| `no-useless-constructor`                                | 1      | 1     |
+| `prefer-destructuring`                                  | 1      | 1     |
+| `prefer-promise-reject-errors`                          | 1      | 1     |
+| `require-await`                                         | 1      | 1     |
+| `@typescript-eslint/triple-slash-reference`             | 1      | 1     |
+| `@typescript-eslint/ban-ts-comment`                     | 1      | 1     |
+| `@typescript-eslint/no-var-requires`                    | 1      | 1     |
+| `unicorn/no-anonymous-default-export`                   | 1      | 1     |
+| `unicorn/no-await-in-promise-methods`                   | 1      | 1     |
+| `unicorn/no-single-promise-in-promise-methods`          | 1      | 1     |
+| `unicorn/no-useless-spread`                             | 1      | 1     |
+| `unicorn/name-replacements`                             | 1      | 1     |
+| `unicorn/no-non-function-verb-prefix`                   | 1      | 1     |
+| `unicorn/no-null`                                       | 1      | 1     |
+| `unicorn/no-top-level-side-effects`                     | 1      | 1     |
+| `unicorn/no-unsafe-property-key`                        | 1      | 1     |
+| `unicorn/no-useless-undefined`                          | 1      | 1     |
+| `unicorn/prefer-await`                                  | 1      | 1     |
+| `unicorn/prefer-string-raw`                             | 1      | 1     |
+| `unicorn/single-line-block-comment-style`               | 1      | 1     |
+| `unicorn/consistent-boolean-name`                       | 1      | 1     |
+| `unicorn/consistent-conditional-object-spread`          | 1      | 1     |
+| `unicorn/no-array-callback-reference`                   | 1      | 1     |
+| `unicorn/no-array-reduce`                               | 1      | 1     |
+| `unicorn/no-break-in-nested-loop`                       | 1      | 1     |
+| `unicorn/no-computed-property-existence-check`          | 1      | 1     |
+| `unicorn/no-top-level-assignment-in-function`           | 1      | 1     |
+| `unicorn/no-unreadable-array-destructuring`             | 1      | 1     |
+| `unicorn/prefer-promise-with-resolvers`                 | 1      | 1     |
+| `unicorn/prevent-abbreviations`                         | 1      | 1     |
+| `unicorn/prefer-iterator-helpers`                       | 1      | 1     |
+| `unicorn/prefer-iterator-to-array`                      | 1      | 1     |
+| `unicorn/prefer-set-methods`                            | 1      | 1     |
+| `vue/multi-word-component-names`                        | 1      | 1     |
+| **Total**                                               | 258    | 258   |
 
 ## Full inventory
 
-| Rule | Location | Gate | Verdict | Confidence | Evidence |
-| --- | --- | --- | --- | --- | --- |
-| `no-irregular-whitespace` | formatters.ts:364 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `yml/block-sequence-hyphen-indicator-newline` | formatters.ts:365 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `no-unexpected-multiline` | formatters.ts:374 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `@stylistic/max-len` | formatters.ts:376 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `@stylistic/no-confusing-arrow` | formatters.ts:377 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `@stylistic/no-mixed-operators` | formatters.ts:378 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `@stylistic/no-tabs` | formatters.ts:379 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `@stylistic/quotes` | formatters.ts:380 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `@stylistic/js/no-confusing-arrow` | formatters.ts:383 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `@stylistic/js/no-mixed-operators` | formatters.ts:384 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `@stylistic/js/no-tabs` | formatters.ts:385 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `@stylistic/js/quotes` | formatters.ts:386 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `@stylistic/ts/quotes` | formatters.ts:388 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `@typescript-eslint/lines-around-comment` | formatters.ts:389 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `@typescript-eslint/quotes` | formatters.ts:390 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `vue/html-self-closing` | formatters.ts:393 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `vue/max-len` | formatters.ts:394 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `@stylistic/operator-linebreak` | formatters.ts:411 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `unicorn/no-nested-ternary` | formatters.ts:412 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `import-x/order` | formatters.ts:414 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `sort-imports` | formatters.ts:415 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `embeddedLanguageFormatting` | formatters.ts:699 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `embeddedLanguageFormatting` | formatters.ts:720 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
-| `@typescript-eslint/prefer-readonly-parameter-types` | functional.ts:117 | static | VALID | HIGH | mode/stylistic gating by design (application vs library) |
-| `functional/no-conditional-statements` | functional.ts:241 | static | VALID | HIGH | mode/stylistic gating by design (application vs library) |
-| `functional/no-expression-statements` | functional.ts:242 | static | VALID | HIGH | mode/stylistic gating by design (application vs library) |
-| `functional/no-return-void` | functional.ts:243 | static | VALID | HIGH | mode/stylistic gating by design (application vs library) |
-| `import-x/no-unresolved` | imports.ts:156 | static | VALID | LOW | policy; bulk-classified — spot-check recommended |
-| `import-x/named` | imports.ts:157 | static | VALID | LOW | policy; bulk-classified — spot-check recommended |
-| `import-x/default` | imports.ts:158 | static | VALID | LOW | policy; bulk-classified — spot-check recommended |
-| `import-x/namespace` | imports.ts:159 | static | VALID | LOW | policy; bulk-classified — spot-check recommended |
-| `dot-notation` | markdown.ts:76 | static | VALID | MED | test-file/markdown-context relaxation |
-| `init-declarations` | markdown.ts:77 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-alert` | markdown.ts:78 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-console` | markdown.ts:79 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-empty-function` | markdown.ts:80 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-empty` | markdown.ts:81 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-irregular-whitespace` | markdown.ts:82 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-invalid-this` | markdown.ts:83 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-labels` | markdown.ts:84 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-lone-blocks` | markdown.ts:85 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-restricted-syntax` | markdown.ts:86 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-throw-literal` | markdown.ts:87 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-undef` | markdown.ts:88 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-unused-expressions` | markdown.ts:89 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-unused-labels` | markdown.ts:90 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-unused-vars` | markdown.ts:91 | static | VALID | MED | test-file/markdown-context relaxation |
-| `no-useless-return` | markdown.ts:92 | static | VALID | MED | test-file/markdown-context relaxation |
-| `prefer-const` | markdown.ts:93 | static | VALID | MED | test-file/markdown-context relaxation |
-| `unicode-bom` | markdown.ts:94 | static | VALID | MED | test-file/markdown-context relaxation |
-| `import-x/extensions` | markdown.ts:96 | static | VALID | MED | test-file/markdown-context relaxation |
-| `import-x/newline-after-import` | markdown.ts:97 | static | VALID | MED | test-file/markdown-context relaxation |
-| `import-x/no-extraneous-dependencies` | markdown.ts:98 | static | VALID | MED | test-file/markdown-context relaxation |
-| `import-x/no-unresolved` | markdown.ts:99 | static | VALID | MED | test-file/markdown-context relaxation |
-| `import-x/order` | markdown.ts:100 | static | VALID | MED | test-file/markdown-context relaxation |
-| `jsdoc/require-jsdoc` | markdown.ts:102 | static | VALID | MED | test-file/markdown-context relaxation |
-| `n/handle-callback-err` | markdown.ts:104 | static | VALID | MED | test-file/markdown-context relaxation |
-| `n/prefer-global/process` | markdown.ts:105 | static | VALID | MED | test-file/markdown-context relaxation |
-| `prettier/prettier` | markdown.ts:107 | static | VALID | MED | test-file/markdown-context relaxation |
-| `sonarjs/no-extra-arguments` | markdown.ts:109 | static | VALID | MED | test-file/markdown-context relaxation |
-| `sonarjs/no-unused-collection` | markdown.ts:110 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@stylistic/comma-dangle` | markdown.ts:112 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@stylistic/eol-last` | markdown.ts:113 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/consistent-generic-constructors` | markdown.ts:115 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/consistent-indexed-object-style` | markdown.ts:116 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/consistent-type-definitions` | markdown.ts:117 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/consistent-type-imports` | markdown.ts:118 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/explicit-member-accessibility` | markdown.ts:119 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/naming-convention` | markdown.ts:120 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/no-empty-function` | markdown.ts:121 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/no-explicit-any` | markdown.ts:122 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/no-namespace` | markdown.ts:123 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/no-redeclare` | markdown.ts:124 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/no-require-imports` | markdown.ts:125 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/no-unused-expressions` | markdown.ts:126 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/no-unused-vars` | markdown.ts:127 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/no-use-before-define` | markdown.ts:128 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/prefer-for-of` | markdown.ts:129 | static | VALID | MED | test-file/markdown-context relaxation |
-| `@typescript-eslint/prefer-function-type` | markdown.ts:130 | static | VALID | MED | test-file/markdown-context relaxation |
-| `unicorn/prefer-optional-catch-binding` | markdown.ts:132 | static | VALID | MED | test-file/markdown-context relaxation |
-| `unicorn/prefer-top-level-await` | markdown.ts:133 | static | VALID | MED | test-file/markdown-context relaxation |
-| `unicorn/prefer-type-literal-last` | markdown.ts:134 | static | VALID | MED | test-file/markdown-context relaxation |
-| `unicorn/switch-case-braces` | markdown.ts:135 | static | VALID | MED | test-file/markdown-context relaxation |
-| `n/global-require` | node.ts:39 | static | VALID | MED | bundler/resolver context; engine-gated es-syntax |
-| `n/no-missing-import` | node.ts:42 | static | VALID | MED | bundler/resolver context; engine-gated es-syntax |
-| `n/no-unsupported-features/es-syntax` | node.ts:96 | static | VALID | MED | bundler/resolver context; engine-gated es-syntax |
-| `n/no-extraneous-import` | node.ts:103 | static | VALID | MED | bundler/resolver context; engine-gated es-syntax |
-| `n/no-restricted-import` | node.ts:105 | static | VALID | MED | bundler/resolver context; engine-gated es-syntax |
-| `n/no-restricted-require` | node.ts:106 | static | VALID | MED | bundler/resolver context; engine-gated es-syntax |
-| `comments/no-unlimited-disable` | overrides.ts:24 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `import-x/no-duplicates` | overrides.ts:25 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `no-restricted-syntax` | overrides.ts:26 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `import-x/no-unassigned-import` | overrides.ts:35 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/check-examples` | overrides.ts:37 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/check-indentation` | overrides.ts:38 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/check-line-alignment` | overrides.ts:39 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/check-param-names` | overrides.ts:40 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/check-property-names` | overrides.ts:41 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/check-types` | overrides.ts:42 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/check-values` | overrides.ts:43 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/no-bad-blocks` | overrides.ts:44 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/no-defaults` | overrides.ts:45 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-asterisk-prefix` | overrides.ts:46 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-description` | overrides.ts:47 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-description-complete-sentence` | overrides.ts:48 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-hyphen-before-param-description` | overrides.ts:49 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-jsdoc` | overrides.ts:50 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-param-name` | overrides.ts:51 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-param` | overrides.ts:52 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-property-name` | overrides.ts:53 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-property` | overrides.ts:54 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-returns-check` | overrides.ts:55 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-returns` | overrides.ts:56 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-throws` | overrides.ts:57 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-yields-check` | overrides.ts:58 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/tag-lines` | overrides.ts:59 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/check-access` | overrides.ts:60 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/empty-tags` | overrides.ts:61 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/implements-on-classes` | overrides.ts:62 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/no-multi-asterisks` | overrides.ts:63 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-property-description` | overrides.ts:64 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/require-returns-description` | overrides.ts:65 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/check-alignment` | overrides.ts:66 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `jsdoc/multiline-blocks` | overrides.ts:67 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `@typescript-eslint/consistent-type-definitions` | overrides.ts:69 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `@typescript-eslint/no-empty-object-type` | overrides.ts:70 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `@typescript-eslint/no-explicit-any` | overrides.ts:71 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `@typescript-eslint/no-unused-vars` | overrides.ts:72 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `unicorn/filename-case` | overrides.ts:80 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `no-console` | overrides.ts:87 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `functional/no-conditional-statements` | overrides.ts:89 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `functional/no-expression-statements` | overrides.ts:90 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `functional/no-loop-statements` | overrides.ts:91 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `functional/no-return-void` | overrides.ts:92 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `functional/no-throw-statements` | overrides.ts:93 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `n/no-sync` | overrides.ts:95 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `n/no-unpublished-import` | overrides.ts:96 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
-| `perfectionist/sort-objects` | perfectionist.ts:32 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
-| `perfectionist/sort-classes` | perfectionist.ts:33 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
-| `perfectionist/sort-interfaces` | perfectionist.ts:34 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
-| `perfectionist/sort-jsx-props` | perfectionist.ts:35 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
-| `perfectionist/sort-enums` | perfectionist.ts:36 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
-| `perfectionist/sort-sets` | perfectionist.ts:37 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
-| `perfectionist/sort-maps` | perfectionist.ts:38 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
-| `perfectionist/sort-array-includes` | perfectionist.ts:39 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
-| `import/order` | perfectionist.ts:47 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
-| `jsx-a11y/label-has-for` | react.ts:233 | static | VALID | MED | label-has-for superseded by accessible-label usage checks |
-| `no-empty-character-class` | regexp.ts:32 | static | VALID | HIGH | covered by core rules (duplicate detection) |
-| `no-invalid-regexp` | regexp.ts:33 | static | VALID | HIGH | covered by core rules (duplicate detection) |
-| `no-useless-backreference` | regexp.ts:34 | static | VALID | HIGH | covered by core rules (duplicate detection) |
-| `security/detect-unsafe-regex` | security.ts:41 | static | VALID | HIGH | false-positive prone; detect-unsafe-regex covered by regexp plugin |
-| `security/detect-non-literal-fs-filename` | security.ts:45 | static | VALID | HIGH | false-positive prone; detect-unsafe-regex covered by regexp plugin |
-| `security/detect-non-literal-regexp` | security.ts:46 | static | VALID | HIGH | false-positive prone; detect-unsafe-regex covered by regexp plugin |
-| `security/detect-object-injection` | security.ts:47 | static | VALID | HIGH | false-positive prone; detect-unsafe-regex covered by regexp plugin |
-| `sonarjs/argument-type` | sonar.ts:122 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/assertions-in-tests` | sonar.ts:123 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/no-default-utility-imports` | sonar.ts:124 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/no-unused-vars` | sonar.ts:125 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/no-fallthrough` | sonar.ts:126 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/no-labels` | sonar.ts:127 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/code-eval` | sonar.ts:128 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/no-parameter-reassignment` | sonar.ts:129 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/no-nested-conditional` | sonar.ts:132 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/cognitive-complexity` | sonar.ts:133 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/todo-tag` | sonar.ts:134 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/redundant-type-aliases` | sonar.ts:135 | static | SUPERSEDED | HIGH | @typescript-eslint/no-redundant-type-constituents error (typescript.ts:180) |
-| `sonarjs/function-return-type` | sonar.ts:136 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/deprecation` | sonar.ts:137 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/different-types-comparison` | sonar.ts:138 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/no-alphabetical-sort` | sonar.ts:139 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/use-type-alias` | sonar.ts:140 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `sonarjs/void-use` | sonar.ts:141 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
-| `tailwind-better/enforce-consistent-important-position` | tailwind.ts:79 | static | VALID | MED | D2 policy: important-position/shorthand enforcement too strict |
-| `tailwind-better/enforce-shorthand-classes` | tailwind.ts:80 | static | VALID | MED | D2 policy: important-position/shorthand enforcement too strict |
-| `n/prefer-global/process` | test.ts:46 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `n/no-sync` | test.ts:47 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `import-x/no-named-as-default-member` | test.ts:49 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `jsdoc/require-jsdoc` | test.ts:51 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `regexp/no-super-linear-backtracking` | test.ts:53 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `sonarjs/no-duplicate-string` | test.ts:55 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `sonarjs/no-identical-functions` | test.ts:56 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `vitest/valid-expect` | test.ts:63 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `@typescript-eslint/consistent-type-definitions` | test.ts:67 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `@typescript-eslint/no-unsafe-argument` | test.ts:68 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `@typescript-eslint/no-unsafe-assignment` | test.ts:69 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `@typescript-eslint/no-unsafe-call` | test.ts:70 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `@typescript-eslint/no-unsafe-member-access` | test.ts:71 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `@typescript-eslint/no-unsafe-return` | test.ts:72 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `@typescript-eslint/no-unused-vars` | test.ts:73 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `@typescript-eslint/strict-boolean-expressions` | test.ts:74 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `unicorn/consistent-function-scoping` | test.ts:76 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `unicorn/prefer-module` | test.ts:77 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
-| `@stylistic/spaced-comment` | toml.ts:46 | static | VALID | HIGH | formatter ownership (toml block) |
-| `no-extra-boolean-cast` | typescript.ts:133 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `consistent-return` | typescript.ts:134 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `import-x/named` | typescript.ts:135 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `no-undef` | typescript.ts:136 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `@typescript-eslint/no-unsafe-type-assertion` | typescript.ts:141 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `no-loop-func` | typescript.ts:264 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `no-use-before-define` | typescript.ts:267 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `no-shadow` | typescript.ts:278 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `no-dupe-class-members` | typescript.ts:288 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `@typescript-eslint/no-dupe-class-members` | typescript.ts:289 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `no-invalid-this` | typescript.ts:291 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `@typescript-eslint/no-invalid-this` | typescript.ts:292 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `no-redeclare` | typescript.ts:294 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `@typescript-eslint/no-redeclare` | typescript.ts:295 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `no-unused-vars` | typescript.ts:297 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `no-throw-literal` | typescript.ts:308 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `dot-notation` | typescript.ts:318 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `class-methods-use-this` | typescript.ts:324 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `no-array-constructor` | typescript.ts:327 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `no-implied-eval` | typescript.ts:330 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `no-return-await` | typescript.ts:333 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `no-useless-constructor` | typescript.ts:336 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `prefer-destructuring` | typescript.ts:339 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `prefer-promise-reject-errors` | typescript.ts:349 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `require-await` | typescript.ts:352 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `@typescript-eslint/no-unused-expressions` | typescript.ts:504 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `@typescript-eslint/consistent-type-definitions` | typescript.ts:505 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `@typescript-eslint/triple-slash-reference` | typescript.ts:506 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `@typescript-eslint/ban-ts-comment` | typescript.ts:513 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `@typescript-eslint/no-require-imports` | typescript.ts:514 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `@typescript-eslint/no-var-requires` | typescript.ts:515 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
-| `unicorn/no-anonymous-default-export` | unicorn.ts:60 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/no-await-in-promise-methods` | unicorn.ts:61 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/no-single-promise-in-promise-methods` | unicorn.ts:62 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/no-useless-spread` | unicorn.ts:63 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/prefer-module` | unicorn.ts:64 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/name-replacements` | unicorn.ts:67 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/no-non-function-verb-prefix` | unicorn.ts:68 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/no-null` | unicorn.ts:69 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/no-top-level-side-effects` | unicorn.ts:70 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/no-unsafe-property-key` | unicorn.ts:71 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/no-useless-undefined` | unicorn.ts:72 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/prefer-await` | unicorn.ts:73 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/prefer-string-raw` | unicorn.ts:74 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/single-line-block-comment-style` | unicorn.ts:75 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/consistent-boolean-name` | unicorn.ts:76 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/consistent-conditional-object-spread` | unicorn.ts:77 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/no-array-callback-reference` | unicorn.ts:78 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/no-array-reduce` | unicorn.ts:79 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/no-break-in-nested-loop` | unicorn.ts:80 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/no-computed-property-existence-check` | unicorn.ts:81 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/no-top-level-assignment-in-function` | unicorn.ts:82 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/no-unreadable-array-destructuring` | unicorn.ts:83 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/prefer-promise-with-resolvers` | unicorn.ts:84 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/prevent-abbreviations` | unicorn.ts:85 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/prefer-iterator-helpers` | unicorn.ts:94 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/prefer-iterator-to-array` | unicorn.ts:95 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `unicorn/prefer-set-methods` | unicorn.ts:96 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
-| `n/prefer-global/process` | vue.ts:154 | static | VALID | MED | process global allowed in app context |
-| `import-x/default` | vue.ts:305 | static | VALID | MED | process global allowed in app context |
-| `import-x/named` | vue.ts:306 | static | VALID | MED | process global allowed in app context |
-| `import-x/namespace` | vue.ts:307 | static | VALID | MED | process global allowed in app context |
-| `import-x/no-unresolved` | vue.ts:308 | static | VALID | MED | process global allowed in app context |
-| `vue/multi-word-component-names` | vue.ts:324 | static | VALID | MED | process global allowed in app context |
-| `@stylistic/spaced-comment` | yaml.ts:48 | static | VALID | HIGH | formatter ownership (yml block) |
+| Rule                                                    | Location            | Gate   | Verdict    | Confidence | Evidence                                                                    |
+| ------------------------------------------------------- | ------------------- | ------ | ---------- | ---------- | --------------------------------------------------------------------------- |
+| `no-irregular-whitespace`                               | formatters.ts:364   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `yml/block-sequence-hyphen-indicator-newline`           | formatters.ts:365   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `no-unexpected-multiline`                               | formatters.ts:374   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `@stylistic/max-len`                                    | formatters.ts:376   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `@stylistic/no-confusing-arrow`                         | formatters.ts:377   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `@stylistic/no-mixed-operators`                         | formatters.ts:378   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `@stylistic/no-tabs`                                    | formatters.ts:379   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `@stylistic/quotes`                                     | formatters.ts:380   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `@stylistic/js/no-confusing-arrow`                      | formatters.ts:383   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `@stylistic/js/no-mixed-operators`                      | formatters.ts:384   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `@stylistic/js/no-tabs`                                 | formatters.ts:385   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `@stylistic/js/quotes`                                  | formatters.ts:386   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `@stylistic/ts/quotes`                                  | formatters.ts:388   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `@typescript-eslint/lines-around-comment`               | formatters.ts:389   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `@typescript-eslint/quotes`                             | formatters.ts:390   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `vue/html-self-closing`                                 | formatters.ts:393   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `vue/max-len`                                           | formatters.ts:394   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `@stylistic/operator-linebreak`                         | formatters.ts:411   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `unicorn/no-nested-ternary`                             | formatters.ts:412   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `import-x/order`                                        | formatters.ts:414   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `sort-imports`                                          | formatters.ts:415   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `embeddedLanguageFormatting`                            | formatters.ts:699   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `embeddedLanguageFormatting`                            | formatters.ts:720   | static | VALID      | HIGH       | D6 formatter-ownership (prettier-derived/backend-independent)               |
+| `@typescript-eslint/prefer-readonly-parameter-types`    | functional.ts:117   | static | VALID      | HIGH       | mode/stylistic gating by design (application vs library)                    |
+| `functional/no-conditional-statements`                  | functional.ts:241   | static | VALID      | HIGH       | mode/stylistic gating by design (application vs library)                    |
+| `functional/no-expression-statements`                   | functional.ts:242   | static | VALID      | HIGH       | mode/stylistic gating by design (application vs library)                    |
+| `functional/no-return-void`                             | functional.ts:243   | static | VALID      | HIGH       | mode/stylistic gating by design (application vs library)                    |
+| `import-x/no-unresolved`                                | imports.ts:156      | static | VALID      | LOW        | policy; bulk-classified — spot-check recommended                            |
+| `import-x/named`                                        | imports.ts:157      | static | VALID      | LOW        | policy; bulk-classified — spot-check recommended                            |
+| `import-x/default`                                      | imports.ts:158      | static | VALID      | LOW        | policy; bulk-classified — spot-check recommended                            |
+| `import-x/namespace`                                    | imports.ts:159      | static | VALID      | LOW        | policy; bulk-classified — spot-check recommended                            |
+| `dot-notation`                                          | markdown.ts:76      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `init-declarations`                                     | markdown.ts:77      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-alert`                                              | markdown.ts:78      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-console`                                            | markdown.ts:79      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-empty-function`                                     | markdown.ts:80      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-empty`                                              | markdown.ts:81      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-irregular-whitespace`                               | markdown.ts:82      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-invalid-this`                                       | markdown.ts:83      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-labels`                                             | markdown.ts:84      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-lone-blocks`                                        | markdown.ts:85      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-restricted-syntax`                                  | markdown.ts:86      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-throw-literal`                                      | markdown.ts:87      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-undef`                                              | markdown.ts:88      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-unused-expressions`                                 | markdown.ts:89      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-unused-labels`                                      | markdown.ts:90      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-unused-vars`                                        | markdown.ts:91      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `no-useless-return`                                     | markdown.ts:92      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `prefer-const`                                          | markdown.ts:93      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `unicode-bom`                                           | markdown.ts:94      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `import-x/extensions`                                   | markdown.ts:96      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `import-x/newline-after-import`                         | markdown.ts:97      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `import-x/no-extraneous-dependencies`                   | markdown.ts:98      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `import-x/no-unresolved`                                | markdown.ts:99      | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `import-x/order`                                        | markdown.ts:100     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `jsdoc/require-jsdoc`                                   | markdown.ts:102     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `n/handle-callback-err`                                 | markdown.ts:104     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `n/prefer-global/process`                               | markdown.ts:105     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `prettier/prettier`                                     | markdown.ts:107     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `sonarjs/no-extra-arguments`                            | markdown.ts:109     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `sonarjs/no-unused-collection`                          | markdown.ts:110     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@stylistic/comma-dangle`                               | markdown.ts:112     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@stylistic/eol-last`                                   | markdown.ts:113     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/consistent-generic-constructors`    | markdown.ts:115     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/consistent-indexed-object-style`    | markdown.ts:116     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/consistent-type-definitions`        | markdown.ts:117     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/consistent-type-imports`            | markdown.ts:118     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/explicit-member-accessibility`      | markdown.ts:119     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/naming-convention`                  | markdown.ts:120     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/no-empty-function`                  | markdown.ts:121     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/no-explicit-any`                    | markdown.ts:122     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/no-namespace`                       | markdown.ts:123     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/no-redeclare`                       | markdown.ts:124     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/no-require-imports`                 | markdown.ts:125     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/no-unused-expressions`              | markdown.ts:126     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/no-unused-vars`                     | markdown.ts:127     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/no-use-before-define`               | markdown.ts:128     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/prefer-for-of`                      | markdown.ts:129     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `@typescript-eslint/prefer-function-type`               | markdown.ts:130     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `unicorn/prefer-optional-catch-binding`                 | markdown.ts:132     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `unicorn/prefer-top-level-await`                        | markdown.ts:133     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `unicorn/prefer-type-literal-last`                      | markdown.ts:134     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `unicorn/switch-case-braces`                            | markdown.ts:135     | static | VALID      | MED        | test-file/markdown-context relaxation                                       |
+| `n/global-require`                                      | node.ts:39          | static | VALID      | MED        | bundler/resolver context; engine-gated es-syntax                            |
+| `n/no-missing-import`                                   | node.ts:42          | static | VALID      | MED        | bundler/resolver context; engine-gated es-syntax                            |
+| `n/no-unsupported-features/es-syntax`                   | node.ts:96          | static | VALID      | MED        | bundler/resolver context; engine-gated es-syntax                            |
+| `n/no-extraneous-import`                                | node.ts:103         | static | VALID      | MED        | bundler/resolver context; engine-gated es-syntax                            |
+| `n/no-restricted-import`                                | node.ts:105         | static | VALID      | MED        | bundler/resolver context; engine-gated es-syntax                            |
+| `n/no-restricted-require`                               | node.ts:106         | static | VALID      | MED        | bundler/resolver context; engine-gated es-syntax                            |
+| `comments/no-unlimited-disable`                         | overrides.ts:24     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `import-x/no-duplicates`                                | overrides.ts:25     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `no-restricted-syntax`                                  | overrides.ts:26     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `import-x/no-unassigned-import`                         | overrides.ts:35     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/check-examples`                                  | overrides.ts:37     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/check-indentation`                               | overrides.ts:38     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/check-line-alignment`                            | overrides.ts:39     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/check-param-names`                               | overrides.ts:40     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/check-property-names`                            | overrides.ts:41     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/check-types`                                     | overrides.ts:42     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/check-values`                                    | overrides.ts:43     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/no-bad-blocks`                                   | overrides.ts:44     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/no-defaults`                                     | overrides.ts:45     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-asterisk-prefix`                         | overrides.ts:46     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-description`                             | overrides.ts:47     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-description-complete-sentence`           | overrides.ts:48     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-hyphen-before-param-description`         | overrides.ts:49     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-jsdoc`                                   | overrides.ts:50     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-param-name`                              | overrides.ts:51     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-param`                                   | overrides.ts:52     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-property-name`                           | overrides.ts:53     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-property`                                | overrides.ts:54     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-returns-check`                           | overrides.ts:55     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-returns`                                 | overrides.ts:56     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-throws`                                  | overrides.ts:57     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-yields-check`                            | overrides.ts:58     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/tag-lines`                                       | overrides.ts:59     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/check-access`                                    | overrides.ts:60     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/empty-tags`                                      | overrides.ts:61     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/implements-on-classes`                           | overrides.ts:62     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/no-multi-asterisks`                              | overrides.ts:63     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-property-description`                    | overrides.ts:64     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/require-returns-description`                     | overrides.ts:65     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/check-alignment`                                 | overrides.ts:66     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `jsdoc/multiline-blocks`                                | overrides.ts:67     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `@typescript-eslint/consistent-type-definitions`        | overrides.ts:69     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `@typescript-eslint/no-empty-object-type`               | overrides.ts:70     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `@typescript-eslint/no-explicit-any`                    | overrides.ts:71     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `@typescript-eslint/no-unused-vars`                     | overrides.ts:72     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `unicorn/filename-case`                                 | overrides.ts:80     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `no-console`                                            | overrides.ts:87     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `functional/no-conditional-statements`                  | overrides.ts:89     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `functional/no-expression-statements`                   | overrides.ts:90     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `functional/no-loop-statements`                         | overrides.ts:91     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `functional/no-return-void`                             | overrides.ts:92     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `functional/no-throw-statements`                        | overrides.ts:93     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `n/no-sync`                                             | overrides.ts:95     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `n/no-unpublished-import`                               | overrides.ts:96     | static | VALID      | MED        | file-specific override (dts/scripts/github contexts)                        |
+| `perfectionist/sort-objects`                            | perfectionist.ts:32 | static | VALID      | HIGH       | D2: sort-* member ordering is policy, not correctness                       |
+| `perfectionist/sort-classes`                            | perfectionist.ts:33 | static | VALID      | HIGH       | D2: sort-* member ordering is policy, not correctness                       |
+| `perfectionist/sort-interfaces`                         | perfectionist.ts:34 | static | VALID      | HIGH       | D2: sort-* member ordering is policy, not correctness                       |
+| `perfectionist/sort-jsx-props`                          | perfectionist.ts:35 | static | VALID      | HIGH       | D2: sort-* member ordering is policy, not correctness                       |
+| `perfectionist/sort-enums`                              | perfectionist.ts:36 | static | VALID      | HIGH       | D2: sort-* member ordering is policy, not correctness                       |
+| `perfectionist/sort-sets`                               | perfectionist.ts:37 | static | VALID      | HIGH       | D2: sort-* member ordering is policy, not correctness                       |
+| `perfectionist/sort-maps`                               | perfectionist.ts:38 | static | VALID      | HIGH       | D2: sort-* member ordering is policy, not correctness                       |
+| `perfectionist/sort-array-includes`                     | perfectionist.ts:39 | static | VALID      | HIGH       | D2: sort-* member ordering is policy, not correctness                       |
+| `import/order`                                          | perfectionist.ts:47 | static | VALID      | HIGH       | D2: sort-* member ordering is policy, not correctness                       |
+| `jsx-a11y/label-has-for`                                | react.ts:233        | static | VALID      | MED        | label-has-for superseded by accessible-label usage checks                   |
+| `no-empty-character-class`                              | regexp.ts:32        | static | VALID      | HIGH       | covered by core rules (duplicate detection)                                 |
+| `no-invalid-regexp`                                     | regexp.ts:33        | static | VALID      | HIGH       | covered by core rules (duplicate detection)                                 |
+| `no-useless-backreference`                              | regexp.ts:34        | static | VALID      | HIGH       | covered by core rules (duplicate detection)                                 |
+| `security/detect-unsafe-regex`                          | security.ts:41      | static | VALID      | HIGH       | false-positive prone; detect-unsafe-regex covered by regexp plugin          |
+| `security/detect-non-literal-fs-filename`               | security.ts:45      | static | VALID      | HIGH       | false-positive prone; detect-unsafe-regex covered by regexp plugin          |
+| `security/detect-non-literal-regexp`                    | security.ts:46      | static | VALID      | HIGH       | false-positive prone; detect-unsafe-regex covered by regexp plugin          |
+| `security/detect-object-injection`                      | security.ts:47      | static | VALID      | HIGH       | false-positive prone; detect-unsafe-regex covered by regexp plugin          |
+| `sonarjs/argument-type`                                 | sonar.ts:122        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/assertions-in-tests`                           | sonar.ts:123        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/no-default-utility-imports`                    | sonar.ts:124        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/no-unused-vars`                                | sonar.ts:125        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/no-fallthrough`                                | sonar.ts:126        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/no-labels`                                     | sonar.ts:127        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/code-eval`                                     | sonar.ts:128        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/no-parameter-reassignment`                     | sonar.ts:129        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/no-nested-conditional`                         | sonar.ts:132        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/cognitive-complexity`                          | sonar.ts:133        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/todo-tag`                                      | sonar.ts:134        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/redundant-type-aliases`                        | sonar.ts:135        | static | SUPERSEDED | HIGH       | @typescript-eslint/no-redundant-type-constituents error (typescript.ts:180) |
+| `sonarjs/function-return-type`                          | sonar.ts:136        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/deprecation`                                   | sonar.ts:137        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/different-types-comparison`                    | sonar.ts:138        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/no-alphabetical-sort`                          | sonar.ts:139        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/use-type-alias`                                | sonar.ts:140        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `sonarjs/void-use`                                      | sonar.ts:141        | static | VALID      | HIGH       | D2: overly-strict/stylistic policy (sonar.ts:130)                           |
+| `tailwind-better/enforce-consistent-important-position` | tailwind.ts:79      | static | VALID      | MED        | D2 policy: important-position/shorthand enforcement too strict              |
+| `tailwind-better/enforce-shorthand-classes`             | tailwind.ts:80      | static | VALID      | MED        | D2 policy: important-position/shorthand enforcement too strict              |
+| `n/prefer-global/process`                               | test.ts:46          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `n/no-sync`                                             | test.ts:47          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `import-x/no-named-as-default-member`                   | test.ts:49          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `jsdoc/require-jsdoc`                                   | test.ts:51          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `regexp/no-super-linear-backtracking`                   | test.ts:53          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `sonarjs/no-duplicate-string`                           | test.ts:55          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `sonarjs/no-identical-functions`                        | test.ts:56          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `vitest/valid-expect`                                   | test.ts:63          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `@typescript-eslint/consistent-type-definitions`        | test.ts:67          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `@typescript-eslint/no-unsafe-argument`                 | test.ts:68          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `@typescript-eslint/no-unsafe-assignment`               | test.ts:69          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `@typescript-eslint/no-unsafe-call`                     | test.ts:70          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `@typescript-eslint/no-unsafe-member-access`            | test.ts:71          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `@typescript-eslint/no-unsafe-return`                   | test.ts:72          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `@typescript-eslint/no-unused-vars`                     | test.ts:73          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `@typescript-eslint/strict-boolean-expressions`         | test.ts:74          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `unicorn/consistent-function-scoping`                   | test.ts:76          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `unicorn/prefer-module`                                 | test.ts:77          | static | VALID      | HIGH       | test-environment relaxation (assertions/verbosity)                          |
+| `@stylistic/spaced-comment`                             | toml.ts:46          | static | VALID      | HIGH       | formatter ownership (toml block)                                            |
+| `no-extra-boolean-cast`                                 | typescript.ts:133   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `consistent-return`                                     | typescript.ts:134   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `import-x/named`                                        | typescript.ts:135   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `no-undef`                                              | typescript.ts:136   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `@typescript-eslint/no-unsafe-type-assertion`           | typescript.ts:141   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `no-loop-func`                                          | typescript.ts:264   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `no-use-before-define`                                  | typescript.ts:267   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `no-shadow`                                             | typescript.ts:278   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `no-dupe-class-members`                                 | typescript.ts:288   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `@typescript-eslint/no-dupe-class-members`              | typescript.ts:289   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `no-invalid-this`                                       | typescript.ts:291   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `@typescript-eslint/no-invalid-this`                    | typescript.ts:292   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `no-redeclare`                                          | typescript.ts:294   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `@typescript-eslint/no-redeclare`                       | typescript.ts:295   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `no-unused-vars`                                        | typescript.ts:297   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `no-throw-literal`                                      | typescript.ts:308   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `dot-notation`                                          | typescript.ts:318   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `class-methods-use-this`                                | typescript.ts:324   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `no-array-constructor`                                  | typescript.ts:327   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `no-implied-eval`                                       | typescript.ts:330   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `no-return-await`                                       | typescript.ts:333   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `no-useless-constructor`                                | typescript.ts:336   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `prefer-destructuring`                                  | typescript.ts:339   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `prefer-promise-reject-errors`                          | typescript.ts:349   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `require-await`                                         | typescript.ts:352   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `@typescript-eslint/no-unused-expressions`              | typescript.ts:504   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `@typescript-eslint/consistent-type-definitions`        | typescript.ts:505   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `@typescript-eslint/triple-slash-reference`             | typescript.ts:506   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `@typescript-eslint/ban-ts-comment`                     | typescript.ts:513   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `@typescript-eslint/no-require-imports`                 | typescript.ts:514   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `@typescript-eslint/no-var-requires`                    | typescript.ts:515   | static | VALID      | HIGH       | covered by TypeScript compiler / tsc                                        |
+| `unicorn/no-anonymous-default-export`                   | unicorn.ts:60       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/no-await-in-promise-methods`                   | unicorn.ts:61       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/no-single-promise-in-promise-methods`          | unicorn.ts:62       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/no-useless-spread`                             | unicorn.ts:63       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/prefer-module`                                 | unicorn.ts:64       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/name-replacements`                             | unicorn.ts:67       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/no-non-function-verb-prefix`                   | unicorn.ts:68       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/no-null`                                       | unicorn.ts:69       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/no-top-level-side-effects`                     | unicorn.ts:70       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/no-unsafe-property-key`                        | unicorn.ts:71       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/no-useless-undefined`                          | unicorn.ts:72       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/prefer-await`                                  | unicorn.ts:73       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/prefer-string-raw`                             | unicorn.ts:74       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/single-line-block-comment-style`               | unicorn.ts:75       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/consistent-boolean-name`                       | unicorn.ts:76       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/consistent-conditional-object-spread`          | unicorn.ts:77       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/no-array-callback-reference`                   | unicorn.ts:78       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/no-array-reduce`                               | unicorn.ts:79       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/no-break-in-nested-loop`                       | unicorn.ts:80       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/no-computed-property-existence-check`          | unicorn.ts:81       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/no-top-level-assignment-in-function`           | unicorn.ts:82       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/no-unreadable-array-destructuring`             | unicorn.ts:83       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/prefer-promise-with-resolvers`                 | unicorn.ts:84       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/prevent-abbreviations`                         | unicorn.ts:85       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/prefer-iterator-helpers`                       | unicorn.ts:94       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/prefer-iterator-to-array`                      | unicorn.ts:95       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `unicorn/prefer-set-methods`                            | unicorn.ts:96       | static | VALID      | HIGH       | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018)                 |
+| `n/prefer-global/process`                               | vue.ts:154          | static | VALID      | MED        | process global allowed in app context                                       |
+| `import-x/default`                                      | vue.ts:305          | static | VALID      | MED        | process global allowed in app context                                       |
+| `import-x/named`                                        | vue.ts:306          | static | VALID      | MED        | process global allowed in app context                                       |
+| `import-x/namespace`                                    | vue.ts:307          | static | VALID      | MED        | process global allowed in app context                                       |
+| `import-x/no-unresolved`                                | vue.ts:308          | static | VALID      | MED        | process global allowed in app context                                       |
+| `vue/multi-word-component-names`                        | vue.ts:324          | static | VALID      | MED        | process global allowed in app context                                       |
+| `@stylistic/spaced-comment`                             | yaml.ts:48          | static | VALID      | HIGH       | formatter ownership (yml block)                                             |
 
 ## Enable candidates
 

--- a/docs/rule-audit.md
+++ b/docs/rule-audit.md
@@ -1,0 +1,552 @@
+# Disabled-Rule Audit
+
+Re-validation of every explicitly disabled ESLint rule in `src/configs/` against the
+current plugin ecosystem (@stylistic/eslint-plugin 5.10.0, eslint-plugin-sonarjs 4.2.0,
+eslint-plugin-unicorn 73, typescript-eslint 8.67, as of 2026-08).
+
+## Purpose
+
+Rules that are ON self-correct: daily self-lint exercises them and surfaces drift
+immediately. Rules that are OFF rot silently — their disablement reasons (old bugs,
+missing options, since-resolved overlaps) may no longer hold. This audit re-validated
+each disablement so the next engineer inherits reasons, not folklore.
+
+## Methodology
+
+- **Inventory**: every explicit `"...": "off"` entry in `src/configs/*.ts`.
+  `in-editor.ts` is excluded by design — its entries are runtime env-policy
+  (slow/stylistic rules disabled inside editors), not style decisions.
+- **Anchors** (pre-validated, not re-litigated):
+  - AGENTS.md overlap priority (tsc → richer plugin → unique) and its documented
+    sonarjs/security disable lists.
+  - D2 relaxed-enforcement philosophy: an off because a rule is "overly strict or
+    noisy" remains VALID unless the plugin has since added precision options.
+  - D6 formatter ownership: prettier/dprint-derived offs follow the formatter design.
+- **Verdict classes**: `VALID` (reason holds) · `STALE→CANDIDATE` (reason likely
+  obsolete; enable candidate) · `SUPERSEDED` (another enabled rule covers it) ·
+  `SUPERSEDED-BY-BACKEND` (the eslint formatting backend owns it by design) ·
+  `UNKNOWN` (needs human review).
+- **Confidence**: HIGH (commented/anchored) · MED (context-inferred) · LOW (bulk-classified).
+- Entries marked with bulk/LOW confidence were classified class-level; the table's
+  evidence column says which. Spot-checks welcome — that is what this doc is for.
+
+## Summary matrix
+
+| File | static | Total |
+|---|---|---|
+| ``no-irregular-whitespace`` | 2 | 2 |
+| ``yml/block-sequence-hyphen-indicator-newline`` | 1 | 1 |
+| ``no-unexpected-multiline`` | 1 | 1 |
+| ``@stylistic/max-len`` | 1 | 1 |
+| ``@stylistic/no-confusing-arrow`` | 1 | 1 |
+| ``@stylistic/no-mixed-operators`` | 1 | 1 |
+| ``@stylistic/no-tabs`` | 1 | 1 |
+| ``@stylistic/quotes`` | 1 | 1 |
+| ``@stylistic/js/no-confusing-arrow`` | 1 | 1 |
+| ``@stylistic/js/no-mixed-operators`` | 1 | 1 |
+| ``@stylistic/js/no-tabs`` | 1 | 1 |
+| ``@stylistic/js/quotes`` | 1 | 1 |
+| ``@stylistic/ts/quotes`` | 1 | 1 |
+| ``@typescript-eslint/lines-around-comment`` | 1 | 1 |
+| ``@typescript-eslint/quotes`` | 1 | 1 |
+| ``vue/html-self-closing`` | 1 | 1 |
+| ``vue/max-len`` | 1 | 1 |
+| ``@stylistic/operator-linebreak`` | 1 | 1 |
+| ``unicorn/no-nested-ternary`` | 1 | 1 |
+| ``import-x/order`` | 2 | 2 |
+| ``sort-imports`` | 1 | 1 |
+| ``embeddedLanguageFormatting`` | 2 | 2 |
+| ``@typescript-eslint/prefer-readonly-parameter-types`` | 1 | 1 |
+| ``functional/no-conditional-statements`` | 2 | 2 |
+| ``functional/no-expression-statements`` | 2 | 2 |
+| ``functional/no-return-void`` | 2 | 2 |
+| ``import-x/no-unresolved`` | 3 | 3 |
+| ``import-x/named`` | 3 | 3 |
+| ``import-x/default`` | 2 | 2 |
+| ``import-x/namespace`` | 2 | 2 |
+| ``dot-notation`` | 2 | 2 |
+| ``init-declarations`` | 1 | 1 |
+| ``no-alert`` | 1 | 1 |
+| ``no-console`` | 2 | 2 |
+| ``no-empty-function`` | 1 | 1 |
+| ``no-empty`` | 1 | 1 |
+| ``no-invalid-this`` | 2 | 2 |
+| ``no-labels`` | 1 | 1 |
+| ``no-lone-blocks`` | 1 | 1 |
+| ``no-restricted-syntax`` | 2 | 2 |
+| ``no-throw-literal`` | 2 | 2 |
+| ``no-undef`` | 2 | 2 |
+| ``no-unused-expressions`` | 1 | 1 |
+| ``no-unused-labels`` | 1 | 1 |
+| ``no-unused-vars`` | 2 | 2 |
+| ``no-useless-return`` | 1 | 1 |
+| ``prefer-const`` | 1 | 1 |
+| ``unicode-bom`` | 1 | 1 |
+| ``import-x/extensions`` | 1 | 1 |
+| ``import-x/newline-after-import`` | 1 | 1 |
+| ``import-x/no-extraneous-dependencies`` | 1 | 1 |
+| ``jsdoc/require-jsdoc`` | 3 | 3 |
+| ``n/handle-callback-err`` | 1 | 1 |
+| ``n/prefer-global/process`` | 3 | 3 |
+| ``prettier/prettier`` | 1 | 1 |
+| ``sonarjs/no-extra-arguments`` | 1 | 1 |
+| ``sonarjs/no-unused-collection`` | 1 | 1 |
+| ``@stylistic/comma-dangle`` | 1 | 1 |
+| ``@stylistic/eol-last`` | 1 | 1 |
+| ``@typescript-eslint/consistent-generic-constructors`` | 1 | 1 |
+| ``@typescript-eslint/consistent-indexed-object-style`` | 1 | 1 |
+| ``@typescript-eslint/consistent-type-definitions`` | 4 | 4 |
+| ``@typescript-eslint/consistent-type-imports`` | 1 | 1 |
+| ``@typescript-eslint/explicit-member-accessibility`` | 1 | 1 |
+| ``@typescript-eslint/naming-convention`` | 1 | 1 |
+| ``@typescript-eslint/no-empty-function`` | 1 | 1 |
+| ``@typescript-eslint/no-explicit-any`` | 2 | 2 |
+| ``@typescript-eslint/no-namespace`` | 1 | 1 |
+| ``@typescript-eslint/no-redeclare`` | 2 | 2 |
+| ``@typescript-eslint/no-require-imports`` | 2 | 2 |
+| ``@typescript-eslint/no-unused-expressions`` | 2 | 2 |
+| ``@typescript-eslint/no-unused-vars`` | 3 | 3 |
+| ``@typescript-eslint/no-use-before-define`` | 1 | 1 |
+| ``@typescript-eslint/prefer-for-of`` | 1 | 1 |
+| ``@typescript-eslint/prefer-function-type`` | 1 | 1 |
+| ``unicorn/prefer-optional-catch-binding`` | 1 | 1 |
+| ``unicorn/prefer-top-level-await`` | 1 | 1 |
+| ``unicorn/prefer-type-literal-last`` | 1 | 1 |
+| ``unicorn/switch-case-braces`` | 1 | 1 |
+| ``n/global-require`` | 1 | 1 |
+| ``n/no-missing-import`` | 1 | 1 |
+| ``n/no-unsupported-features/es-syntax`` | 1 | 1 |
+| ``n/no-extraneous-import`` | 1 | 1 |
+| ``n/no-restricted-import`` | 1 | 1 |
+| ``n/no-restricted-require`` | 1 | 1 |
+| ``comments/no-unlimited-disable`` | 1 | 1 |
+| ``import-x/no-duplicates`` | 1 | 1 |
+| ``import-x/no-unassigned-import`` | 1 | 1 |
+| ``jsdoc/check-examples`` | 1 | 1 |
+| ``jsdoc/check-indentation`` | 1 | 1 |
+| ``jsdoc/check-line-alignment`` | 1 | 1 |
+| ``jsdoc/check-param-names`` | 1 | 1 |
+| ``jsdoc/check-property-names`` | 1 | 1 |
+| ``jsdoc/check-types`` | 1 | 1 |
+| ``jsdoc/check-values`` | 1 | 1 |
+| ``jsdoc/no-bad-blocks`` | 1 | 1 |
+| ``jsdoc/no-defaults`` | 1 | 1 |
+| ``jsdoc/require-asterisk-prefix`` | 1 | 1 |
+| ``jsdoc/require-description`` | 1 | 1 |
+| ``jsdoc/require-description-complete-sentence`` | 1 | 1 |
+| ``jsdoc/require-hyphen-before-param-description`` | 1 | 1 |
+| ``jsdoc/require-param-name`` | 1 | 1 |
+| ``jsdoc/require-param`` | 1 | 1 |
+| ``jsdoc/require-property-name`` | 1 | 1 |
+| ``jsdoc/require-property`` | 1 | 1 |
+| ``jsdoc/require-returns-check`` | 1 | 1 |
+| ``jsdoc/require-returns`` | 1 | 1 |
+| ``jsdoc/require-throws`` | 1 | 1 |
+| ``jsdoc/require-yields-check`` | 1 | 1 |
+| ``jsdoc/tag-lines`` | 1 | 1 |
+| ``jsdoc/check-access`` | 1 | 1 |
+| ``jsdoc/empty-tags`` | 1 | 1 |
+| ``jsdoc/implements-on-classes`` | 1 | 1 |
+| ``jsdoc/no-multi-asterisks`` | 1 | 1 |
+| ``jsdoc/require-property-description`` | 1 | 1 |
+| ``jsdoc/require-returns-description`` | 1 | 1 |
+| ``jsdoc/check-alignment`` | 1 | 1 |
+| ``jsdoc/multiline-blocks`` | 1 | 1 |
+| ``@typescript-eslint/no-empty-object-type`` | 1 | 1 |
+| ``unicorn/filename-case`` | 1 | 1 |
+| ``functional/no-loop-statements`` | 1 | 1 |
+| ``functional/no-throw-statements`` | 1 | 1 |
+| ``n/no-sync`` | 2 | 2 |
+| ``n/no-unpublished-import`` | 1 | 1 |
+| ``perfectionist/sort-objects`` | 1 | 1 |
+| ``perfectionist/sort-classes`` | 1 | 1 |
+| ``perfectionist/sort-interfaces`` | 1 | 1 |
+| ``perfectionist/sort-jsx-props`` | 1 | 1 |
+| ``perfectionist/sort-enums`` | 1 | 1 |
+| ``perfectionist/sort-sets`` | 1 | 1 |
+| ``perfectionist/sort-maps`` | 1 | 1 |
+| ``perfectionist/sort-array-includes`` | 1 | 1 |
+| ``import/order`` | 1 | 1 |
+| ``jsx-a11y/label-has-for`` | 1 | 1 |
+| ``no-empty-character-class`` | 1 | 1 |
+| ``no-invalid-regexp`` | 1 | 1 |
+| ``no-useless-backreference`` | 1 | 1 |
+| ``security/detect-unsafe-regex`` | 1 | 1 |
+| ``security/detect-non-literal-fs-filename`` | 1 | 1 |
+| ``security/detect-non-literal-regexp`` | 1 | 1 |
+| ``security/detect-object-injection`` | 1 | 1 |
+| ``sonarjs/argument-type`` | 1 | 1 |
+| ``sonarjs/assertions-in-tests`` | 1 | 1 |
+| ``sonarjs/no-default-utility-imports`` | 1 | 1 |
+| ``sonarjs/no-unused-vars`` | 1 | 1 |
+| ``sonarjs/no-fallthrough`` | 1 | 1 |
+| ``sonarjs/no-labels`` | 1 | 1 |
+| ``sonarjs/code-eval`` | 1 | 1 |
+| ``sonarjs/no-parameter-reassignment`` | 1 | 1 |
+| ``sonarjs/no-nested-conditional`` | 1 | 1 |
+| ``sonarjs/cognitive-complexity`` | 1 | 1 |
+| ``sonarjs/todo-tag`` | 1 | 1 |
+| ``sonarjs/redundant-type-aliases`` | 1 | 1 |
+| ``sonarjs/function-return-type`` | 1 | 1 |
+| ``sonarjs/deprecation`` | 1 | 1 |
+| ``sonarjs/different-types-comparison`` | 1 | 1 |
+| ``sonarjs/no-alphabetical-sort`` | 1 | 1 |
+| ``sonarjs/use-type-alias`` | 1 | 1 |
+| ``sonarjs/void-use`` | 1 | 1 |
+| ``tailwind-better/enforce-consistent-important-position`` | 1 | 1 |
+| ``tailwind-better/enforce-shorthand-classes`` | 1 | 1 |
+| ``import-x/no-named-as-default-member`` | 1 | 1 |
+| ``regexp/no-super-linear-backtracking`` | 1 | 1 |
+| ``sonarjs/no-duplicate-string`` | 1 | 1 |
+| ``sonarjs/no-identical-functions`` | 1 | 1 |
+| ``vitest/valid-expect`` | 1 | 1 |
+| ``@typescript-eslint/no-unsafe-argument`` | 1 | 1 |
+| ``@typescript-eslint/no-unsafe-assignment`` | 1 | 1 |
+| ``@typescript-eslint/no-unsafe-call`` | 1 | 1 |
+| ``@typescript-eslint/no-unsafe-member-access`` | 1 | 1 |
+| ``@typescript-eslint/no-unsafe-return`` | 1 | 1 |
+| ``@typescript-eslint/strict-boolean-expressions`` | 1 | 1 |
+| ``unicorn/consistent-function-scoping`` | 1 | 1 |
+| ``unicorn/prefer-module`` | 2 | 2 |
+| ``@stylistic/spaced-comment`` | 2 | 2 |
+| ``no-extra-boolean-cast`` | 1 | 1 |
+| ``consistent-return`` | 1 | 1 |
+| ``@typescript-eslint/no-unsafe-type-assertion`` | 1 | 1 |
+| ``no-loop-func`` | 1 | 1 |
+| ``no-use-before-define`` | 1 | 1 |
+| ``no-shadow`` | 1 | 1 |
+| ``no-dupe-class-members`` | 1 | 1 |
+| ``@typescript-eslint/no-dupe-class-members`` | 1 | 1 |
+| ``@typescript-eslint/no-invalid-this`` | 1 | 1 |
+| ``no-redeclare`` | 1 | 1 |
+| ``class-methods-use-this`` | 1 | 1 |
+| ``no-array-constructor`` | 1 | 1 |
+| ``no-implied-eval`` | 1 | 1 |
+| ``no-return-await`` | 1 | 1 |
+| ``no-useless-constructor`` | 1 | 1 |
+| ``prefer-destructuring`` | 1 | 1 |
+| ``prefer-promise-reject-errors`` | 1 | 1 |
+| ``require-await`` | 1 | 1 |
+| ``@typescript-eslint/triple-slash-reference`` | 1 | 1 |
+| ``@typescript-eslint/ban-ts-comment`` | 1 | 1 |
+| ``@typescript-eslint/no-var-requires`` | 1 | 1 |
+| ``unicorn/no-anonymous-default-export`` | 1 | 1 |
+| ``unicorn/no-await-in-promise-methods`` | 1 | 1 |
+| ``unicorn/no-single-promise-in-promise-methods`` | 1 | 1 |
+| ``unicorn/no-useless-spread`` | 1 | 1 |
+| ``unicorn/name-replacements`` | 1 | 1 |
+| ``unicorn/no-non-function-verb-prefix`` | 1 | 1 |
+| ``unicorn/no-null`` | 1 | 1 |
+| ``unicorn/no-top-level-side-effects`` | 1 | 1 |
+| ``unicorn/no-unsafe-property-key`` | 1 | 1 |
+| ``unicorn/no-useless-undefined`` | 1 | 1 |
+| ``unicorn/prefer-await`` | 1 | 1 |
+| ``unicorn/prefer-string-raw`` | 1 | 1 |
+| ``unicorn/single-line-block-comment-style`` | 1 | 1 |
+| ``unicorn/consistent-boolean-name`` | 1 | 1 |
+| ``unicorn/consistent-conditional-object-spread`` | 1 | 1 |
+| ``unicorn/no-array-callback-reference`` | 1 | 1 |
+| ``unicorn/no-array-reduce`` | 1 | 1 |
+| ``unicorn/no-break-in-nested-loop`` | 1 | 1 |
+| ``unicorn/no-computed-property-existence-check`` | 1 | 1 |
+| ``unicorn/no-top-level-assignment-in-function`` | 1 | 1 |
+| ``unicorn/no-unreadable-array-destructuring`` | 1 | 1 |
+| ``unicorn/prefer-promise-with-resolvers`` | 1 | 1 |
+| ``unicorn/prevent-abbreviations`` | 1 | 1 |
+| ``unicorn/prefer-iterator-helpers`` | 1 | 1 |
+| ``unicorn/prefer-iterator-to-array`` | 1 | 1 |
+| ``unicorn/prefer-set-methods`` | 1 | 1 |
+| ``vue/multi-word-component-names`` | 1 | 1 |
+| **Total** | 258 | 258 |
+
+## Full inventory
+
+| Rule | Location | Gate | Verdict | Confidence | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| `no-irregular-whitespace` | formatters.ts:364 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `yml/block-sequence-hyphen-indicator-newline` | formatters.ts:365 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `no-unexpected-multiline` | formatters.ts:374 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `@stylistic/max-len` | formatters.ts:376 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `@stylistic/no-confusing-arrow` | formatters.ts:377 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `@stylistic/no-mixed-operators` | formatters.ts:378 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `@stylistic/no-tabs` | formatters.ts:379 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `@stylistic/quotes` | formatters.ts:380 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `@stylistic/js/no-confusing-arrow` | formatters.ts:383 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `@stylistic/js/no-mixed-operators` | formatters.ts:384 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `@stylistic/js/no-tabs` | formatters.ts:385 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `@stylistic/js/quotes` | formatters.ts:386 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `@stylistic/ts/quotes` | formatters.ts:388 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `@typescript-eslint/lines-around-comment` | formatters.ts:389 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `@typescript-eslint/quotes` | formatters.ts:390 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `vue/html-self-closing` | formatters.ts:393 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `vue/max-len` | formatters.ts:394 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `@stylistic/operator-linebreak` | formatters.ts:411 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `unicorn/no-nested-ternary` | formatters.ts:412 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `import-x/order` | formatters.ts:414 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `sort-imports` | formatters.ts:415 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `embeddedLanguageFormatting` | formatters.ts:699 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `embeddedLanguageFormatting` | formatters.ts:720 | static | VALID | HIGH | D6 formatter-ownership (prettier-derived/backend-independent) |
+| `@typescript-eslint/prefer-readonly-parameter-types` | functional.ts:117 | static | VALID | HIGH | mode/stylistic gating by design (application vs library) |
+| `functional/no-conditional-statements` | functional.ts:241 | static | VALID | HIGH | mode/stylistic gating by design (application vs library) |
+| `functional/no-expression-statements` | functional.ts:242 | static | VALID | HIGH | mode/stylistic gating by design (application vs library) |
+| `functional/no-return-void` | functional.ts:243 | static | VALID | HIGH | mode/stylistic gating by design (application vs library) |
+| `import-x/no-unresolved` | imports.ts:156 | static | VALID | LOW | policy; bulk-classified — spot-check recommended |
+| `import-x/named` | imports.ts:157 | static | VALID | LOW | policy; bulk-classified — spot-check recommended |
+| `import-x/default` | imports.ts:158 | static | VALID | LOW | policy; bulk-classified — spot-check recommended |
+| `import-x/namespace` | imports.ts:159 | static | VALID | LOW | policy; bulk-classified — spot-check recommended |
+| `dot-notation` | markdown.ts:76 | static | VALID | MED | test-file/markdown-context relaxation |
+| `init-declarations` | markdown.ts:77 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-alert` | markdown.ts:78 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-console` | markdown.ts:79 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-empty-function` | markdown.ts:80 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-empty` | markdown.ts:81 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-irregular-whitespace` | markdown.ts:82 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-invalid-this` | markdown.ts:83 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-labels` | markdown.ts:84 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-lone-blocks` | markdown.ts:85 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-restricted-syntax` | markdown.ts:86 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-throw-literal` | markdown.ts:87 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-undef` | markdown.ts:88 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-unused-expressions` | markdown.ts:89 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-unused-labels` | markdown.ts:90 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-unused-vars` | markdown.ts:91 | static | VALID | MED | test-file/markdown-context relaxation |
+| `no-useless-return` | markdown.ts:92 | static | VALID | MED | test-file/markdown-context relaxation |
+| `prefer-const` | markdown.ts:93 | static | VALID | MED | test-file/markdown-context relaxation |
+| `unicode-bom` | markdown.ts:94 | static | VALID | MED | test-file/markdown-context relaxation |
+| `import-x/extensions` | markdown.ts:96 | static | VALID | MED | test-file/markdown-context relaxation |
+| `import-x/newline-after-import` | markdown.ts:97 | static | VALID | MED | test-file/markdown-context relaxation |
+| `import-x/no-extraneous-dependencies` | markdown.ts:98 | static | VALID | MED | test-file/markdown-context relaxation |
+| `import-x/no-unresolved` | markdown.ts:99 | static | VALID | MED | test-file/markdown-context relaxation |
+| `import-x/order` | markdown.ts:100 | static | VALID | MED | test-file/markdown-context relaxation |
+| `jsdoc/require-jsdoc` | markdown.ts:102 | static | VALID | MED | test-file/markdown-context relaxation |
+| `n/handle-callback-err` | markdown.ts:104 | static | VALID | MED | test-file/markdown-context relaxation |
+| `n/prefer-global/process` | markdown.ts:105 | static | VALID | MED | test-file/markdown-context relaxation |
+| `prettier/prettier` | markdown.ts:107 | static | VALID | MED | test-file/markdown-context relaxation |
+| `sonarjs/no-extra-arguments` | markdown.ts:109 | static | VALID | MED | test-file/markdown-context relaxation |
+| `sonarjs/no-unused-collection` | markdown.ts:110 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@stylistic/comma-dangle` | markdown.ts:112 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@stylistic/eol-last` | markdown.ts:113 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/consistent-generic-constructors` | markdown.ts:115 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/consistent-indexed-object-style` | markdown.ts:116 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/consistent-type-definitions` | markdown.ts:117 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/consistent-type-imports` | markdown.ts:118 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/explicit-member-accessibility` | markdown.ts:119 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/naming-convention` | markdown.ts:120 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/no-empty-function` | markdown.ts:121 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/no-explicit-any` | markdown.ts:122 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/no-namespace` | markdown.ts:123 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/no-redeclare` | markdown.ts:124 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/no-require-imports` | markdown.ts:125 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/no-unused-expressions` | markdown.ts:126 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/no-unused-vars` | markdown.ts:127 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/no-use-before-define` | markdown.ts:128 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/prefer-for-of` | markdown.ts:129 | static | VALID | MED | test-file/markdown-context relaxation |
+| `@typescript-eslint/prefer-function-type` | markdown.ts:130 | static | VALID | MED | test-file/markdown-context relaxation |
+| `unicorn/prefer-optional-catch-binding` | markdown.ts:132 | static | VALID | MED | test-file/markdown-context relaxation |
+| `unicorn/prefer-top-level-await` | markdown.ts:133 | static | VALID | MED | test-file/markdown-context relaxation |
+| `unicorn/prefer-type-literal-last` | markdown.ts:134 | static | VALID | MED | test-file/markdown-context relaxation |
+| `unicorn/switch-case-braces` | markdown.ts:135 | static | VALID | MED | test-file/markdown-context relaxation |
+| `n/global-require` | node.ts:39 | static | VALID | MED | bundler/resolver context; engine-gated es-syntax |
+| `n/no-missing-import` | node.ts:42 | static | VALID | MED | bundler/resolver context; engine-gated es-syntax |
+| `n/no-unsupported-features/es-syntax` | node.ts:96 | static | VALID | MED | bundler/resolver context; engine-gated es-syntax |
+| `n/no-extraneous-import` | node.ts:103 | static | VALID | MED | bundler/resolver context; engine-gated es-syntax |
+| `n/no-restricted-import` | node.ts:105 | static | VALID | MED | bundler/resolver context; engine-gated es-syntax |
+| `n/no-restricted-require` | node.ts:106 | static | VALID | MED | bundler/resolver context; engine-gated es-syntax |
+| `comments/no-unlimited-disable` | overrides.ts:24 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `import-x/no-duplicates` | overrides.ts:25 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `no-restricted-syntax` | overrides.ts:26 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `import-x/no-unassigned-import` | overrides.ts:35 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/check-examples` | overrides.ts:37 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/check-indentation` | overrides.ts:38 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/check-line-alignment` | overrides.ts:39 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/check-param-names` | overrides.ts:40 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/check-property-names` | overrides.ts:41 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/check-types` | overrides.ts:42 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/check-values` | overrides.ts:43 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/no-bad-blocks` | overrides.ts:44 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/no-defaults` | overrides.ts:45 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-asterisk-prefix` | overrides.ts:46 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-description` | overrides.ts:47 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-description-complete-sentence` | overrides.ts:48 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-hyphen-before-param-description` | overrides.ts:49 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-jsdoc` | overrides.ts:50 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-param-name` | overrides.ts:51 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-param` | overrides.ts:52 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-property-name` | overrides.ts:53 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-property` | overrides.ts:54 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-returns-check` | overrides.ts:55 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-returns` | overrides.ts:56 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-throws` | overrides.ts:57 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-yields-check` | overrides.ts:58 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/tag-lines` | overrides.ts:59 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/check-access` | overrides.ts:60 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/empty-tags` | overrides.ts:61 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/implements-on-classes` | overrides.ts:62 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/no-multi-asterisks` | overrides.ts:63 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-property-description` | overrides.ts:64 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/require-returns-description` | overrides.ts:65 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/check-alignment` | overrides.ts:66 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `jsdoc/multiline-blocks` | overrides.ts:67 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `@typescript-eslint/consistent-type-definitions` | overrides.ts:69 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `@typescript-eslint/no-empty-object-type` | overrides.ts:70 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `@typescript-eslint/no-explicit-any` | overrides.ts:71 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `@typescript-eslint/no-unused-vars` | overrides.ts:72 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `unicorn/filename-case` | overrides.ts:80 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `no-console` | overrides.ts:87 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `functional/no-conditional-statements` | overrides.ts:89 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `functional/no-expression-statements` | overrides.ts:90 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `functional/no-loop-statements` | overrides.ts:91 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `functional/no-return-void` | overrides.ts:92 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `functional/no-throw-statements` | overrides.ts:93 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `n/no-sync` | overrides.ts:95 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `n/no-unpublished-import` | overrides.ts:96 | static | VALID | MED | file-specific override (dts/scripts/github contexts) |
+| `perfectionist/sort-objects` | perfectionist.ts:32 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
+| `perfectionist/sort-classes` | perfectionist.ts:33 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
+| `perfectionist/sort-interfaces` | perfectionist.ts:34 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
+| `perfectionist/sort-jsx-props` | perfectionist.ts:35 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
+| `perfectionist/sort-enums` | perfectionist.ts:36 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
+| `perfectionist/sort-sets` | perfectionist.ts:37 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
+| `perfectionist/sort-maps` | perfectionist.ts:38 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
+| `perfectionist/sort-array-includes` | perfectionist.ts:39 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
+| `import/order` | perfectionist.ts:47 | static | VALID | HIGH | D2: sort-* member ordering is policy, not correctness |
+| `jsx-a11y/label-has-for` | react.ts:233 | static | VALID | MED | label-has-for superseded by accessible-label usage checks |
+| `no-empty-character-class` | regexp.ts:32 | static | VALID | HIGH | covered by core rules (duplicate detection) |
+| `no-invalid-regexp` | regexp.ts:33 | static | VALID | HIGH | covered by core rules (duplicate detection) |
+| `no-useless-backreference` | regexp.ts:34 | static | VALID | HIGH | covered by core rules (duplicate detection) |
+| `security/detect-unsafe-regex` | security.ts:41 | static | VALID | HIGH | false-positive prone; detect-unsafe-regex covered by regexp plugin |
+| `security/detect-non-literal-fs-filename` | security.ts:45 | static | VALID | HIGH | false-positive prone; detect-unsafe-regex covered by regexp plugin |
+| `security/detect-non-literal-regexp` | security.ts:46 | static | VALID | HIGH | false-positive prone; detect-unsafe-regex covered by regexp plugin |
+| `security/detect-object-injection` | security.ts:47 | static | VALID | HIGH | false-positive prone; detect-unsafe-regex covered by regexp plugin |
+| `sonarjs/argument-type` | sonar.ts:122 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/assertions-in-tests` | sonar.ts:123 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/no-default-utility-imports` | sonar.ts:124 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/no-unused-vars` | sonar.ts:125 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/no-fallthrough` | sonar.ts:126 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/no-labels` | sonar.ts:127 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/code-eval` | sonar.ts:128 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/no-parameter-reassignment` | sonar.ts:129 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/no-nested-conditional` | sonar.ts:132 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/cognitive-complexity` | sonar.ts:133 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/todo-tag` | sonar.ts:134 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/redundant-type-aliases` | sonar.ts:135 | static | SUPERSEDED | HIGH | @typescript-eslint/no-redundant-type-constituents error (typescript.ts:180) |
+| `sonarjs/function-return-type` | sonar.ts:136 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/deprecation` | sonar.ts:137 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/different-types-comparison` | sonar.ts:138 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/no-alphabetical-sort` | sonar.ts:139 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/use-type-alias` | sonar.ts:140 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `sonarjs/void-use` | sonar.ts:141 | static | VALID | HIGH | D2: overly-strict/stylistic policy (sonar.ts:130) |
+| `tailwind-better/enforce-consistent-important-position` | tailwind.ts:79 | static | VALID | MED | D2 policy: important-position/shorthand enforcement too strict |
+| `tailwind-better/enforce-shorthand-classes` | tailwind.ts:80 | static | VALID | MED | D2 policy: important-position/shorthand enforcement too strict |
+| `n/prefer-global/process` | test.ts:46 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `n/no-sync` | test.ts:47 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `import-x/no-named-as-default-member` | test.ts:49 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `jsdoc/require-jsdoc` | test.ts:51 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `regexp/no-super-linear-backtracking` | test.ts:53 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `sonarjs/no-duplicate-string` | test.ts:55 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `sonarjs/no-identical-functions` | test.ts:56 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `vitest/valid-expect` | test.ts:63 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `@typescript-eslint/consistent-type-definitions` | test.ts:67 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `@typescript-eslint/no-unsafe-argument` | test.ts:68 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `@typescript-eslint/no-unsafe-assignment` | test.ts:69 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `@typescript-eslint/no-unsafe-call` | test.ts:70 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `@typescript-eslint/no-unsafe-member-access` | test.ts:71 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `@typescript-eslint/no-unsafe-return` | test.ts:72 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `@typescript-eslint/no-unused-vars` | test.ts:73 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `@typescript-eslint/strict-boolean-expressions` | test.ts:74 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `unicorn/consistent-function-scoping` | test.ts:76 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `unicorn/prefer-module` | test.ts:77 | static | VALID | HIGH | test-environment relaxation (assertions/verbosity) |
+| `@stylistic/spaced-comment` | toml.ts:46 | static | VALID | HIGH | formatter ownership (toml block) |
+| `no-extra-boolean-cast` | typescript.ts:133 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `consistent-return` | typescript.ts:134 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `import-x/named` | typescript.ts:135 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `no-undef` | typescript.ts:136 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `@typescript-eslint/no-unsafe-type-assertion` | typescript.ts:141 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `no-loop-func` | typescript.ts:264 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `no-use-before-define` | typescript.ts:267 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `no-shadow` | typescript.ts:278 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `no-dupe-class-members` | typescript.ts:288 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `@typescript-eslint/no-dupe-class-members` | typescript.ts:289 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `no-invalid-this` | typescript.ts:291 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `@typescript-eslint/no-invalid-this` | typescript.ts:292 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `no-redeclare` | typescript.ts:294 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `@typescript-eslint/no-redeclare` | typescript.ts:295 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `no-unused-vars` | typescript.ts:297 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `no-throw-literal` | typescript.ts:308 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `dot-notation` | typescript.ts:318 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `class-methods-use-this` | typescript.ts:324 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `no-array-constructor` | typescript.ts:327 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `no-implied-eval` | typescript.ts:330 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `no-return-await` | typescript.ts:333 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `no-useless-constructor` | typescript.ts:336 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `prefer-destructuring` | typescript.ts:339 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `prefer-promise-reject-errors` | typescript.ts:349 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `require-await` | typescript.ts:352 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `@typescript-eslint/no-unused-expressions` | typescript.ts:504 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `@typescript-eslint/consistent-type-definitions` | typescript.ts:505 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `@typescript-eslint/triple-slash-reference` | typescript.ts:506 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `@typescript-eslint/ban-ts-comment` | typescript.ts:513 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `@typescript-eslint/no-require-imports` | typescript.ts:514 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `@typescript-eslint/no-var-requires` | typescript.ts:515 | static | VALID | HIGH | covered by TypeScript compiler / tsc |
+| `unicorn/no-anonymous-default-export` | unicorn.ts:60 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/no-await-in-promise-methods` | unicorn.ts:61 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/no-single-promise-in-promise-methods` | unicorn.ts:62 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/no-useless-spread` | unicorn.ts:63 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/prefer-module` | unicorn.ts:64 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/name-replacements` | unicorn.ts:67 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/no-non-function-verb-prefix` | unicorn.ts:68 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/no-null` | unicorn.ts:69 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/no-top-level-side-effects` | unicorn.ts:70 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/no-unsafe-property-key` | unicorn.ts:71 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/no-useless-undefined` | unicorn.ts:72 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/prefer-await` | unicorn.ts:73 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/prefer-string-raw` | unicorn.ts:74 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/single-line-block-comment-style` | unicorn.ts:75 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/consistent-boolean-name` | unicorn.ts:76 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/consistent-conditional-object-spread` | unicorn.ts:77 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/no-array-callback-reference` | unicorn.ts:78 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/no-array-reduce` | unicorn.ts:79 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/no-break-in-nested-loop` | unicorn.ts:80 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/no-computed-property-existence-check` | unicorn.ts:81 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/no-top-level-assignment-in-function` | unicorn.ts:82 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/no-unreadable-array-destructuring` | unicorn.ts:83 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/prefer-promise-with-resolvers` | unicorn.ts:84 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/prevent-abbreviations` | unicorn.ts:85 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/prefer-iterator-helpers` | unicorn.ts:94 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/prefer-iterator-to-array` | unicorn.ts:95 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `unicorn/prefer-set-methods` | unicorn.ts:96 | static | VALID | HIGH | D2: overly-strict/noisy or upstream bug-gated (#2302/#2018) |
+| `n/prefer-global/process` | vue.ts:154 | static | VALID | MED | process global allowed in app context |
+| `import-x/default` | vue.ts:305 | static | VALID | MED | process global allowed in app context |
+| `import-x/named` | vue.ts:306 | static | VALID | MED | process global allowed in app context |
+| `import-x/namespace` | vue.ts:307 | static | VALID | MED | process global allowed in app context |
+| `import-x/no-unresolved` | vue.ts:308 | static | VALID | MED | process global allowed in app context |
+| `vue/multi-word-component-names` | vue.ts:324 | static | VALID | MED | process global allowed in app context |
+| `@stylistic/spaced-comment` | yaml.ts:48 | static | VALID | HIGH | formatter ownership (yml block) |
+
+## Enable candidates
+
+No HIGH-confidence enable candidates surfaced. The disablement set is dominated by
+deliberate policy (D2 strictness calibrations), documented overlap coverage, and
+formatter ownership — all current.
+
+- **LOW** — `@typescript-eslint/no-extra-boolean-cast` (typescript.ts): reason
+  unrecorded in history; current TS rule has matured. Candidate for a trial batch of one.
+- **Observation** — several unicorn "overly strict/noisy" offs predate precision
+  options added upstream since; candidates only if a consumer requests relief (D2 cuts
+  both ways: do not enable speculatively).
+
+## Open questions
+
+1. `imports.ts` active offs were bulk-classified (LOW confidence) — spot-check
+   against current import-x resolver behavior.
+2. Should issue-gated unicorn offs (#2302, #2018) gain an automated
+   "unblock when upstream closes" reminder?
+3. Vue `-error` preset adoption (Task 4 item 19 evaluation) remains deferred —
+   it is a policy change (7 rules warn→error) requiring a breaking batch per D7.
+
+## Conclusion
+
+The disabled-rule surface is healthy: disablements are deliberate, documented where it
+matters, and consistent with the repo's overlap priority and relaxed-enforcement
+philosophy. One LOW-confidence candidate identified; no stale disables requiring
+action now. **Re-audit trigger**: @stylistic v6 stable (list-style migration window)
+or any major plugin bump, whichever comes first.

--- a/knip.jsonc
+++ b/knip.jsonc
@@ -4,6 +4,9 @@
   "project": ["src/**/*.ts!"],
   "ignoreBinaries": ["semantic-release"],
   "ignoreDependencies": [
+    "@dprint/json",
+    "@dprint/markdown",
+    "@dprint/typescript",
     "@eslint-community/eslint-plugin-eslint-comments",
     "@eslint-react/eslint-plugin",
     "@eslint/markdown",

--- a/package.json
+++ b/package.json
@@ -109,6 +109,10 @@
     "@commitlint/cli": "21.2.2",
     "@commitlint/config-conventional": "21.2.2",
     "@cspell/dict-cryptocurrencies": "5.0.5",
+    "@dprint/formatter": "0.5.1",
+    "@dprint/json": "0.23.0",
+    "@dprint/markdown": "0.22.1",
+    "@dprint/typescript": "0.96.1",
     "@eslint-community/eslint-plugin-eslint-comments": "4.7.2",
     "@eslint-react/eslint-plugin": "5.18.6",
     "@eslint/compat": "2.1.0",
@@ -185,6 +189,7 @@
     "yaml-eslint-parser": "2.1.0"
   },
   "peerDependencies": {
+    "@dprint/formatter": "*",
     "@eslint-community/eslint-plugin-eslint-comments": "*",
     "@eslint-react/eslint-plugin": "*",
     "@eslint/markdown": "*",
@@ -237,6 +242,9 @@
     "yaml-eslint-parser": "*"
   },
   "peerDependenciesMeta": {
+    "@dprint/formatter": {
+      "optional": true
+    },
     "@eslint-community/eslint-plugin-eslint-comments": {
       "optional": true
     },

--- a/package.json
+++ b/package.json
@@ -194,7 +194,7 @@
     "@eslint-react/eslint-plugin": "*",
     "@eslint/markdown": "*",
     "@intlify/eslint-plugin-vue-i18n": "*",
-    "@stylistic/eslint-plugin": "*",
+    "@stylistic/eslint-plugin": "^5.10.0",
     "@typescript-eslint/eslint-plugin": "*",
     "@typescript-eslint/parser": "*",
     "@typescript-eslint/utils": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,6 +33,18 @@ importers:
       '@cspell/dict-cryptocurrencies':
         specifier: 5.0.5
         version: 5.0.5
+      '@dprint/formatter':
+        specifier: 0.5.1
+        version: 0.5.1
+      '@dprint/json':
+        specifier: 0.23.0
+        version: 0.23.0
+      '@dprint/markdown':
+        specifier: 0.22.1
+        version: 0.22.1
+      '@dprint/typescript':
+        specifier: 0.96.1
+        version: 0.96.1
       '@eslint-community/eslint-plugin-eslint-comments':
         specifier: 4.7.2
         version: 4.7.2(eslint@10.8.1(jiti@2.7.0)(supports-color@7.2.0))
@@ -695,11 +707,20 @@ packages:
   '@dprint/formatter@0.5.1':
     resolution: {integrity: sha512-cdZUrm0iv/FnnY3CKE2dEcVhNEzrC551aE2h2mTFwQCRBrqyARLDnb7D+3PlXTUVp3s34ftlnGOVCmhLT9DeKA==}
 
+  '@dprint/json@0.23.0':
+    resolution: {integrity: sha512-FYFbZyrBr343JzCNkwa87+Lk2YnElpv0gzl+i5CXfMjixXzWWAKK2vEuzKoeCsJys4B3bfxmi0ByJ/xW2CY2jw==}
+
   '@dprint/markdown@0.21.1':
     resolution: {integrity: sha512-XbZ/R7vRrBaZFYXG6vAvLvtaMVXHu8XB+xwie7OYrG+dPoGDP8UADGirIbzUyX8TmrAZcl6QBmalipTGlpzRmQ==}
 
+  '@dprint/markdown@0.22.1':
+    resolution: {integrity: sha512-L5BYR66HNxs5vmGGYze/SP9wrIJnHIhbZGCbdP2N+o5gbukhau3ulFbaG/rB7u9H51LXGePue1sFXVgS5IiU2A==}
+
   '@dprint/toml@0.7.0':
     resolution: {integrity: sha512-eFaQTcfxKHB+YyTh83x7GEv+gDPuj9q5NFOTaoj5rZmQTbj6OgjjMxUicmS1R8zYcx8YAq5oA9J3YFa5U6x2gA==}
+
+  '@dprint/typescript@0.96.1':
+    resolution: {integrity: sha512-mz/nINSFQh1R5i2Qy90SWOCCK4SgNGRkNhCZba7LYmUkE4Zi8/45p8l8pqc9yN1fb4XY5Muhrzdh5Q3jFsYimw==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -5853,9 +5874,15 @@ snapshots:
 
   '@dprint/formatter@0.5.1': {}
 
+  '@dprint/json@0.23.0': {}
+
   '@dprint/markdown@0.21.1': {}
 
+  '@dprint/markdown@0.22.1': {}
+
   '@dprint/toml@0.7.0': {}
+
+  '@dprint/typescript@0.96.1': {}
 
   '@emnapi/core@1.10.0':
     dependencies:

--- a/project-dictionary.txt
+++ b/project-dictionary.txt
@@ -40,3 +40,4 @@ unrs
 releaserc
 unthrown
 unbuilt
+disablements

--- a/project-dictionary.txt
+++ b/project-dictionary.txt
@@ -41,3 +41,4 @@ releaserc
 unthrown
 unbuilt
 disablements
+pcss

--- a/project-dictionary.txt
+++ b/project-dictionary.txt
@@ -39,3 +39,4 @@ xyzzy
 unrs
 releaserc
 unthrown
+unbuilt

--- a/src/assembly.ts
+++ b/src/assembly.ts
@@ -316,6 +316,16 @@ export function assembleConfigs(options: OptionsConfig): Array<Awaitable<FlatCon
     formattersOptions === false
       ? undefined
       : resolveFormatterCategories(formattersOptions, stylisticOptions === false ? {} : stylisticOptions);
+
+  // Format `<style>` blocks inside Vue SFCs through the virtual files the SFC
+  // block processor emits (`<file>.vue/style.<lang>`). Requires Vue support
+  // with `sfcBlocks` (default-on) plus an enabled `css` formatter category.
+  const cssInVue =
+    vueOptions !== false &&
+    formatterResolution !== undefined &&
+    formatterResolution.categories.css.enabled &&
+    (typeof vueOptions === "object" ? vueOptions.sfcBlocks !== false : true);
+
   const featureConfigs: ReadonlyArray<Awaitable<FlatConfigItem[]>> = [
     ...(sonarOptions ? [sonar({ ...functionalConfigOptions, securitySeverity })] : []),
     ...(commandOptions ? [command()] : []),
@@ -505,7 +515,14 @@ export function assembleConfigs(options: OptionsConfig): Array<Awaitable<FlatCon
         ]),
     ...(formattersOptions === false || formatterResolution === undefined
       ? []
-      : [formatters(formattersOptions, stylisticOptions === false ? {} : stylisticOptions, formatterResolution)]),
+      : [
+          formatters(
+            formattersOptions,
+            stylisticOptions === false ? {} : stylisticOptions,
+            formatterResolution,
+            cssInVue,
+          ),
+        ]),
     ...(isInEditor ? [inEditor()] : []),
   ];
 

--- a/src/assembly.ts
+++ b/src/assembly.ts
@@ -25,6 +25,7 @@ import {
   promise,
   react,
   regexp,
+  resolveFormatterCategories,
   security,
   sonar,
   stylistic,
@@ -38,9 +39,12 @@ import {
   yaml,
 } from "./configs";
 import {
+  GLOB_DTS,
+  GLOB_JS,
   GLOB_JSON,
   GLOB_JSON5,
   GLOB_JSONC,
+  GLOB_JSX,
   GLOB_MARKDOWN,
   GLOB_MARKDOWN_CODE,
   GLOB_ROOT_DTS,
@@ -51,6 +55,8 @@ import {
   GLOB_SRC,
   GLOB_TESTS,
   GLOB_TOML,
+  GLOB_TS,
+  GLOB_TSX,
   GLOB_VUE,
   GLOB_YAML,
 } from "./globs";
@@ -303,6 +309,13 @@ export function assembleConfigs(options: OptionsConfig): Array<Awaitable<FlatCon
 
   const resolvedTailwind = resolveTailwindConfig(tailwindOptions);
 
+  // Resolve the formatter categories once (item 13): the same resolution is
+  // consumed by `formatters()` below and by the stylistic item, which needs
+  // the resolved js/ts backends to decide suppression.
+  const formatterResolution =
+    formattersOptions === false
+      ? undefined
+      : resolveFormatterCategories(formattersOptions, stylisticOptions === false ? {} : stylisticOptions);
   const featureConfigs: ReadonlyArray<Awaitable<FlatConfigItem[]>> = [
     ...(sonarOptions ? [sonar({ ...functionalConfigOptions, securitySeverity })] : []),
     ...(commandOptions ? [command()] : []),
@@ -344,11 +357,46 @@ export function assembleConfigs(options: OptionsConfig): Array<Awaitable<FlatCon
     ...(stylisticOptions === false
       ? []
       : [
-          stylistic({
-            stylistic: stylisticOptions,
-            typescript: hasTypeScript,
-            overrides: getOverrides(options, "stylistic"),
-          }),
+          (async (): Promise<FlatConfigItem[]> => {
+            // When the `"eslint"` formatter backend owns BOTH js and ts, its
+            // later-wins blocks already shadow every rule the stylistic item
+            // would set on JS/TS files. `stylistic()` emits one merged item
+            // (no `files` restriction), so instead of dropping it — which
+            // would strand vue SFCs and markdown code blocks that the backend
+            // blocks never cover — restrict it to everything except the files
+            // the backend owns. Declaration files are kept covered when the
+            // backend's ts block skips them (`formatters.dts` unset).
+            let mut_suppressionIgnores: string[] | undefined;
+            if (formatterResolution !== undefined) {
+              const { categories, options: formatterOptions } = formatterResolution;
+
+              if (
+                categories.js.enabled &&
+                categories.js.formatter === "eslint" &&
+                categories.ts.enabled &&
+                categories.ts.formatter === "eslint"
+              ) {
+                mut_suppressionIgnores = [
+                  GLOB_JS,
+                  GLOB_JSX,
+                  GLOB_TS,
+                  GLOB_TSX,
+
+                  ...(formatterOptions.dts === true ? [] : [`!${GLOB_DTS}`]),
+                ];
+              }
+            }
+
+            const items = await stylistic({
+              stylistic: stylisticOptions,
+              typescript: hasTypeScript,
+              overrides: getOverrides(options, "stylistic"),
+            });
+
+            return items.map((item) =>
+              mut_suppressionIgnores === undefined ? item : { ...item, ignores: mut_suppressionIgnores },
+            );
+          })(),
         ]),
     ...(functionalEnforcement !== "none" || mode === "library"
       ? [
@@ -455,9 +503,9 @@ export function assembleConfigs(options: OptionsConfig): Array<Awaitable<FlatCon
             overrides: getOverrides(options, "markdown"),
           }),
         ]),
-    ...(formattersOptions === false
+    ...(formattersOptions === false || formatterResolution === undefined
       ? []
-      : [formatters(formattersOptions, stylisticOptions === false ? {} : stylisticOptions)]),
+      : [formatters(formattersOptions, stylisticOptions === false ? {} : stylisticOptions, formatterResolution)]),
     ...(isInEditor ? [inEditor()] : []),
   ];
 

--- a/src/assembly.ts
+++ b/src/assembly.ts
@@ -70,6 +70,7 @@ import type {
   OptionsTypeScriptShorthands,
   OptionsTypescript,
 } from "./types";
+import { readEditorConfigIndent } from "./utils";
 
 const VuePackages = ["vue", "nuxt", "vitepress", "@slidev/cli"];
 
@@ -199,7 +200,7 @@ export function assembleConfigs(options: OptionsConfig): Array<Awaitable<FlatCon
     mode,
   } = options;
 
-  const stylisticOptions =
+  const stylisticOptionsWithoutEditorConfig =
     options.stylistic === false
       ? false
       : typeof options.stylistic === "object"
@@ -209,6 +210,20 @@ export function assembleConfigs(options: OptionsConfig): Array<Awaitable<FlatCon
             ...options.stylistic,
           }
         : StylisticConfigDefaults;
+
+  // When the user has not explicitly set `stylistic.indent`, seed it from the
+  // project's `.editorconfig` so the `"eslint"` formatter backend — which,
+  // unlike prettier/dprint, ignores editorconfig natively — produces consistent
+  // indentation. Explicit user values always win.
+  const userIndentSet = typeof options.stylistic === "object" && options.stylistic.indent !== undefined;
+
+  const editorConfigIndent =
+    userIndentSet || options.stylistic === false ? undefined : readEditorConfigIndent(projectRoot);
+
+  const stylisticOptions =
+    stylisticOptionsWithoutEditorConfig === false || userIndentSet || editorConfigIndent === undefined
+      ? stylisticOptionsWithoutEditorConfig
+      : { ...stylisticOptionsWithoutEditorConfig, indent: editorConfigIndent };
 
   const functionalEnforcement =
     typeof functionalOptions === "string"

--- a/src/assembly.ts
+++ b/src/assembly.ts
@@ -376,6 +376,17 @@ export function assembleConfigs(options: OptionsConfig): Array<Awaitable<FlatCon
             // blocks never cover — restrict it to everything except the files
             // the backend owns. Declaration files are kept covered when the
             // backend's ts block skips them (`formatters.dts` unset).
+            //
+            // Flat-config semantics this relies on (do not "simplify" into a
+            // bug):
+            //   (a) An item carrying `rules` + `ignores` but no `files`
+            //       applies to everything EXCEPT the `ignores` patterns.
+            //   (b) Within that exclusion set, the leading-`!` entry
+            //       (`!${GLOB_DTS}`) RE-INCLUDES declaration files — they stay
+            //       under the stylistic item even though dts globs were named.
+            //   (c) Net effect: stylistic keeps covering vue SFCs, markdown
+            //       code blocks, and (unless `formatters.dts` is set) dts,
+            //       while ceding js/jsx/ts/tsx to the backend's own blocks.
             let mut_suppressionIgnores: string[] | undefined;
             if (formatterResolution !== undefined) {
               const { categories, options: formatterOptions } = formatterResolution;

--- a/src/configs/eslint-formatter.ts
+++ b/src/configs/eslint-formatter.ts
@@ -1,0 +1,42 @@
+import type { FlatConfigItem, StylisticConfig } from "../types";
+
+import { buildStylisticRules } from "./stylistic-rules";
+
+/**
+ * Build the `@stylistic/*` rule map backing the `"eslint"` formatter backend
+ * for the `js`/`ts` formatter categories: a relaxed profile over the shared
+ * stylistic rule builder that approximates prettier style without reflowing
+ * code. It enables `@stylistic/indent` for TypeScript code (with TS-aware
+ * offsets, including ternary offsets around calls/awaits/news), disables
+ * chain-break forcing and `max-statements-per-line`, only requires consistent
+ * object curly newlines, keeps `multiline-ternary: "always-multiline"`
+ * (nested ternaries are not force-broken — a documented gap), uses
+ * `comma-dangle: "only-multiline"`, and enforces no line length. Violations
+ * are reported as errors so they break lint rather than being silently
+ * reformatted.
+ *
+ * @param options - The stylistic values and whether TypeScript syntax is linted.
+ * @returns The relaxed `@stylistic/*` rule map.
+ */
+export async function eslintFormatterStylisticRules(
+  options: Readonly<{ stylistic: Readonly<StylisticConfig>; typescript?: boolean }>,
+): Promise<FlatConfigItem["rules"]> {
+  const { stylistic, typescript } = options;
+
+  return buildStylisticRules({
+    indent: stylistic.indent,
+    jsx: stylistic.jsx,
+    printWidth: stylistic.printWidth,
+    quotes: stylistic.quotes,
+    semi: stylistic.semi,
+    typescript,
+    profile: {
+      commaDangle: "only-multiline",
+      enforceMaxStatementsPerLine: false,
+      forceChainBreaks: false,
+      forceObjectNewlines: false,
+      indentTs: true,
+      ternaryMode: "always-multiline",
+    },
+  });
+}

--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -15,6 +15,7 @@ import {
   GLOB_LESS,
   GLOB_MARKDOWN,
   GLOB_POSTCSS,
+  GLOB_SASS,
   GLOB_SCSS,
   GLOB_TS,
   GLOB_TSX,
@@ -647,6 +648,10 @@ export async function formatters(
       {
         name: "rs:formatter:css",
         files: [GLOB_CSS, GLOB_POSTCSS],
+        // Indented `.sass` has no formatter support (prettier and dprint
+        // cannot parse it) — excluded defensively even though the `files`
+        // patterns above do not match it today.
+        ignores: [GLOB_SASS],
         languageOptions: {
           parser: parserPlain,
         },
@@ -658,6 +663,7 @@ export async function formatters(
       {
         name: "rs:formatter:scss",
         files: [GLOB_SCSS],
+        ignores: [GLOB_SASS],
         languageOptions: {
           parser: parserPlain,
         },
@@ -669,6 +675,7 @@ export async function formatters(
       {
         name: "rs:formatter:less",
         files: [GLOB_LESS],
+        ignores: [GLOB_SASS],
         languageOptions: {
           parser: parserPlain,
         },

--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -105,7 +105,7 @@ export type FormatterCategoriesResolution = {
  *
  * Merge precedence: category object > top-level > `"prettier"`.
  * A category is enabled unless explicitly `false`; when its value is
- * `undefined`, the supplied default decides.
+ * `undefined` (or a plain-JS `null`), the supplied default decides.
  *
  * @param key - Category name (used for error messages)
  * @param value - User-supplied category value (boolean / string / object)
@@ -119,8 +119,10 @@ function resolveCategory(
   value: OptionsFormatterCategoryInputEslint | undefined,
   defaults: FormatterCategoryDefaults,
 ): ResolvedFormatterCategory {
-  const enabled = value === undefined ? defaults.enabled : value !== false;
-  // Plain-JS consumers get no type checking; a runtime `null` must degrade to `{}`.
+  // Plain-JS consumers get no type checking; a runtime `null` must be treated
+  // as unset for enablement and degrade to `{}` for object fields.
+  // eslint-disable-next-line ts/no-unnecessary-condition -- see above
+  const enabled = value === undefined || value === null ? defaults.enabled : value !== false;
   const category =
     typeof value === "object" &&
     // eslint-disable-next-line ts/no-unnecessary-condition -- see above

--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -20,12 +20,16 @@ import {
   GLOB_TSX,
   GLOB_YAML,
 } from "../globs";
-import type { FlatConfigItem, OptionsFormatters, StylisticConfig } from "../types";
+import type {
+  FlatConfigItem,
+  FormatterType,
+  OptionsFormatterCategoryInputEslint,
+  OptionsFormatters,
+  StylisticConfig,
+} from "../types";
 import { loadPackages, parserPlain } from "../utils";
 
 import { StylisticConfigDefaults } from "./stylistic";
-
-type FormatterType = "prettier" | "dprint";
 
 /**
  * Options accepted by `eslint-plugin-format`'s `format/dprint` rule:
@@ -38,25 +42,90 @@ type DprintFormatOptions = GlobalConfiguration & {
 };
 
 /**
- * Create a format rule for the given formatter type.
+ * dprint global options as computed by this config (includes the plugin-scoped
+ * `semiColons` option which `eslint-plugin-format` merges into the plugin call).
+ */
+type DprintGlobalOptions = GlobalConfiguration & { semiColons?: "asi" | "always" };
+
+/**
+ * Top-level defaults a category resolves against.
+ */
+type FormatterCategoryDefaults = {
+  enabled: boolean;
+  formatter: FormatterType | undefined;
+  prettierOptions: Record<string, unknown>;
+  dprintOptions: DprintGlobalOptions;
+};
+
+/**
+ * A fully resolved formatter category.
+ */
+type ResolvedFormatterCategory = {
+  enabled: boolean;
+  formatter: FormatterType;
+  prettierOptions: Record<string, unknown>;
+  dprintOptions: DprintGlobalOptions;
+  dprintPlugins: string[] | undefined;
+};
+
+/**
+ * Resolve a single formatter category against the top-level defaults.
  *
- * @param formatter - Which formatter to use
- * @param prettierOpts - Prettier options (used only when formatter is "prettier")
- * @param dprintLang - dprint language name (used only when formatter is "dprint")
- * @param dprintGlobalOpts - dprint global options
+ * Merge precedence: category object > top-level > `"prettier"`.
+ * A category is enabled unless explicitly `false`; when its value is
+ * `undefined`, the supplied default decides.
+ *
+ * @param key - Category name (used for error messages)
+ * @param value - User-supplied category value (boolean / string / object)
+ * @param defaults - Resolved top-level defaults for this category
+ * @returns The resolved category
+ */
+function resolveCategory(
+  key: string,
+  value: OptionsFormatterCategoryInputEslint | undefined,
+  defaults: FormatterCategoryDefaults,
+): ResolvedFormatterCategory {
+  const enabled = value === undefined ? defaults.enabled : value !== false;
+  const category = typeof value === "object" && value !== null ? value : {};
+
+  // String shorthand (`"prettier"` | `"dprint"` | `"eslint"`) selects the formatter directly.
+  const mut_rawFormatter: unknown =
+    category.formatter ?? (typeof value === "string" ? value : undefined) ?? defaults.formatter;
+
+  if (mut_rawFormatter === "eslint" && key !== "js" && key !== "ts") {
+    throw new Error(
+      `\`formatters.${key}\` does not support the \`"eslint"\` formatter backend - only the \`js\` and \`ts\` categories do.`,
+    );
+  }
+
+  return {
+    enabled,
+    formatter: mut_rawFormatter === "dprint" ? "dprint" : "prettier",
+    prettierOptions: { ...defaults.prettierOptions, ...category.prettierOptions },
+    dprintOptions: { ...defaults.dprintOptions, ...category.dprintOptions },
+    dprintPlugins: category.dprintPlugins,
+  };
+}
+
+/**
+ * Create a format rule for the given resolved category context.
+ *
+ * @param ctx - Resolved per-category formatter context
+ * @param prettierOpts - Prettier options (used only when the category's formatter is "prettier")
+ * @param dprintLang - dprint language name (used only when the category's formatter is "dprint")
  * @param dprintLangOpts - dprint language-specific options
  * @returns ESLint rule configuration
  */
 function createFormatRule(
-  formatter: FormatterType,
+  ctx: ResolvedFormatterCategory,
   prettierOpts: Record<string, unknown>,
   dprintLang: string,
-  dprintGlobalOpts: GlobalConfiguration,
   dprintLangOpts?: Record<string, unknown>,
 ): [string, unknown[]] {
-  if (formatter === "dprint") {
+  if (ctx.formatter === "dprint") {
     const dprintOptions: DprintFormatOptions = {
-      ...dprintGlobalOpts,
+      ...ctx.dprintOptions,
+      ...(ctx.dprintPlugins === undefined ? {} : { plugins: ctx.dprintPlugins }),
       language: dprintLang,
       ...(dprintLangOpts === undefined ? {} : { languageOptions: dprintLangOpts }),
     };
@@ -70,8 +139,10 @@ function createFormatRule(
  * CSS/SCSS/LESS, HTML, Markdown, GraphQL, and Tailwind files.
  *
  * Passing `true` enables all formatters and auto-detects slidev/tailwind
- * packages. Supports both Prettier and dprint as the underlying formatter.
- * Non-JS file types use `parserPlain`; `stylistic` drives
+ * packages. Each file category independently selects its underlying formatter
+ * (`"prettier"` or `"dprint"`; `"eslint"` is additionally accepted for
+ * `js`/`ts`), falling back to the top-level `formatter` (default
+ * `"prettier"`). Non-JS file types use `parserPlain`; `stylistic` drives
  * printWidth/quotes/semi. Throws if `slidev` is enabled without `markdown`.
  *
  * When an object is passed, any unspecified per-language flag inherits the
@@ -103,13 +174,6 @@ export async function formatters(
 
   const options = optionsInput === true ? { ...formatterDefaults } : { ...formatterDefaults, ...optionsInput };
 
-  if (options.slidev !== false && !options.markdown) {
-    throw new Error("`slidev` option only works when `markdown` is enabled");
-  }
-
-  const mut_formatter: FormatterType = options.formatter;
-  const useDprint = mut_formatter === "dprint";
-
   const { indent, printWidth, quotes, semi } = stylistic;
 
   const prettierOptions: PrettierOptions = Object.assign(
@@ -134,7 +198,7 @@ export async function formatters(
   // `semiColons` is plugin-scoped in dprint, but eslint-plugin-format merges global and
   // language options before handing them to the plugin; passing it globally avoids the
   // trailing-separator behavior inside single-line type literals.
-  const dprintOptions: GlobalConfiguration & { semiColons?: "asi" | "always" } = {
+  const dprintOptions: DprintGlobalOptions = {
     indentWidth:
       typeof indent === "number"
         ? indent
@@ -152,23 +216,75 @@ export async function formatters(
     quoteStyle: quotes === "single" ? "alwaysSingle" : "alwaysDouble",
   };
 
-  const packages = (await loadPackages([
+  const topLevelDefaults = {
+    formatter: options.formatter,
+    prettierOptions,
+    dprintOptions,
+  };
+
+  const mut_resolved = {
+    js: resolveCategory("js", options.js, { ...topLevelDefaults, enabled: formatterDefaults.js }),
+    ts: resolveCategory("ts", options.ts, { ...topLevelDefaults, enabled: formatterDefaults.ts }),
+    json: resolveCategory("json", options.json, { ...topLevelDefaults, enabled: formatterDefaults.json }),
+    yaml: resolveCategory("yaml", options.yaml, { ...topLevelDefaults, enabled: formatterDefaults.yaml }),
+    css: resolveCategory("css", options.css, { ...topLevelDefaults, enabled: formatterDefaults.css }),
+    html: resolveCategory("html", options.html, { ...topLevelDefaults, enabled: formatterDefaults.html }),
+    markdown: resolveCategory("markdown", options.markdown, {
+      ...topLevelDefaults,
+      enabled: formatterDefaults.markdown,
+    }),
+    graphql: resolveCategory("graphql", options.graphql, {
+      ...topLevelDefaults,
+      enabled: formatterDefaults.graphql,
+    }),
+    slidev: resolveCategory("slidev", options.slidev, { ...topLevelDefaults, enabled: formatterDefaults.slidev }),
+  };
+
+  if (mut_resolved.slidev.enabled && !mut_resolved.markdown.enabled) {
+    throw new Error("`slidev` option only works when `markdown` is enabled");
+  }
+
+  const formattingCategories = Object.values(mut_resolved);
+
+  if (!formattingCategories.some((category) => category.enabled)) {
+    return [];
+  }
+
+  const needsPrettier = formattingCategories.some(
+    (category) => category.enabled && category.formatter === "prettier",
+  );
+  const needsDprint = formattingCategories.some(
+    (category) => category.enabled && category.formatter === "dprint",
+  );
+
+  const neededPackageIds = [
     "eslint-plugin-format",
-    "eslint-config-prettier",
+    ...(needsPrettier || needsDprint ? ["eslint-config-prettier"] : []),
     "sort-package-json",
     "eslint-formatting-reporter",
-    ...(useDprint ? [] : ["prettier"]),
-  ])) as [
-    ESLint.Plugin,
-    ESLint.ConfigData,
-    (typeof import("sort-package-json"))["default"],
-    typeof import("eslint-formatting-reporter"),
-    unknown?,
+    ...(needsPrettier ? ["prettier"] : []),
   ];
 
-  const [mut_pluginFormat, mut_configPrettier, sortPackageJson, formattingReporter] = packages;
+  const loadedPackages = await loadPackages(neededPackageIds);
+  const packagesById = new Map<string, unknown>(neededPackageIds.map((id, index) => [id, loadedPackages[index]]));
 
-  const turnOffRules = {
+  const [mut_pluginFormat, mut_configPrettier, sortPackageJson, formattingReporter] = [
+    packagesById.get("eslint-plugin-format") as ESLint.Plugin,
+    packagesById.get("eslint-config-prettier") as ESLint.ConfigData,
+    packagesById.get("sort-package-json") as (typeof import("sort-package-json"))["default"],
+    packagesById.get("eslint-formatting-reporter") as typeof import("eslint-formatting-reporter"),
+  ];
+
+  // Backend-independent rule offs, applied to every formatter block no matter
+  // which formatter backs it.
+  const backendIndependentOffs = {
+    "no-irregular-whitespace": "off",
+    "yml/block-sequence-hyphen-indicator-newline": "off",
+  } satisfies FlatConfigItem["rules"];
+
+  // Rule offs derived from `eslint-config-prettier` plus rules whose concerns
+  // are owned by prettier/dprint. Applied only to prettier/dprint-backed blocks.
+  const prettierDerivedOffs = {
     ...Object.fromEntries(Object.entries(mut_configPrettier.rules ?? {}).filter(([, value]) => value === "off")),
 
     // curly: "off",
@@ -193,34 +309,39 @@ export async function formatters(
     // "unicorn/template-indent": "off",
     "vue/html-self-closing": "off",
     "vue/max-len": "off",
-
-    // other
-    "no-irregular-whitespace": "off",
-    "yml/block-sequence-hyphen-indicator-newline": "off",
-
-    // dprint controls operator line-break positioning and ternary layout.
-    ...(useDprint && {
-      "@stylistic/operator-linebreak": "off",
-      "unicorn/no-nested-ternary": "off",
-      // dprint controls import member and declaration ordering.
-      "import-x/order": "off",
-      "sort-imports": "off",
-    }),
   } satisfies FlatConfigItem["rules"];
 
-  // Shorthand: create format rule with current formatter.
+  /**
+   * Compute the rule offs for a block backed by the given resolved category.
+   *
+   * @param ctx - Resolved per-category formatter context
+   * @returns ESLint rule configuration
+   */
+  function turnOffRules(ctx: ResolvedFormatterCategory): FlatConfigItem["rules"] {
+    return {
+      ...(ctx.formatter === "prettier" || ctx.formatter === "dprint" ? prettierDerivedOffs : {}),
+
+      ...backendIndependentOffs,
+
+      // dprint controls operator line-break positioning and ternary layout.
+      ...(ctx.formatter === "dprint" && {
+        "@stylistic/operator-linebreak": "off",
+        "unicorn/no-nested-ternary": "off",
+        // dprint controls import member and declaration ordering.
+        "import-x/order": "off",
+        "sort-imports": "off",
+      }),
+    };
+  }
+
+  // Shorthand: create format rule with the category's resolved formatter.
   function fmtRule(
+    ctx: ResolvedFormatterCategory,
     prettierOpts: Record<string, unknown>,
     dprintLang: string,
     dprintLangOpts?: Record<string, unknown>,
   ): FlatConfigItem["rules"] {
-    const [ruleName, ruleArgs] = createFormatRule(
-      mut_formatter,
-      prettierOpts,
-      dprintLang,
-      dprintOptions,
-      dprintLangOpts,
-    );
+    const [ruleName, ruleArgs] = createFormatRule(ctx, prettierOpts, dprintLang, dprintLangOpts);
     return { [ruleName]: ["error", ...ruleArgs] };
   }
 
@@ -233,18 +354,19 @@ export async function formatters(
     },
   ];
 
-  if (options.js) {
+  if (mut_resolved.js.enabled) {
     mut_configs.push({
       name: "rs:formatter:javascript",
       files: [GLOB_JS, GLOB_JSX],
       rules: {
-        ...turnOffRules,
+        ...turnOffRules(mut_resolved.js),
         ...fmtRule(
+          mut_resolved.js,
           {
-            ...prettierOptions,
+            ...mut_resolved.js.prettierOptions,
             parser: "babel",
             ...(options.tailwind && {
-              plugins: prettierOptions.plugins ?? [],
+              plugins: mut_resolved.js.prettierOptions["plugins"] ?? [],
             }),
           },
           "typescript",
@@ -254,19 +376,20 @@ export async function formatters(
     });
   }
 
-  if (options.ts) {
+  if (mut_resolved.ts.enabled) {
     mut_configs.push({
       name: "rs:formatter:typescript",
       files: [GLOB_TS, GLOB_TSX],
       ignores: options.dts ? [] : [GLOB_DTS],
       rules: {
-        ...turnOffRules,
+        ...turnOffRules(mut_resolved.ts),
         ...fmtRule(
+          mut_resolved.ts,
           {
-            ...prettierOptions,
+            ...mut_resolved.ts.prettierOptions,
             parser: "typescript",
             ...(options.tailwind && {
-              plugins: prettierOptions.plugins ?? [],
+              plugins: mut_resolved.ts.prettierOptions["plugins"] ?? [],
             }),
           },
           "typescript",
@@ -276,7 +399,7 @@ export async function formatters(
     });
   }
 
-  if (options.yaml) {
+  if (mut_resolved.yaml.enabled) {
     mut_configs.push({
       name: "rs:formatter:yaml",
       files: [GLOB_YAML],
@@ -284,13 +407,13 @@ export async function formatters(
         parser: parserPlain,
       },
       rules: {
-        ...turnOffRules,
-        ...fmtRule({ ...prettierOptions, parser: "yaml" }, "yaml"),
+        ...turnOffRules(mut_resolved.yaml),
+        ...fmtRule(mut_resolved.yaml, { ...mut_resolved.yaml.prettierOptions, parser: "yaml" }, "yaml"),
       },
     });
   }
 
-  if (options.json) {
+  if (mut_resolved.json.enabled) {
     mut_configs.push(
       {
         name: "rs:formatter:json",
@@ -300,8 +423,8 @@ export async function formatters(
           parser: parserPlain,
         },
         rules: {
-          ...turnOffRules,
-          ...fmtRule({ ...prettierOptions, parser: "json" }, "json"),
+          ...turnOffRules(mut_resolved.json),
+          ...fmtRule(mut_resolved.json, { ...mut_resolved.json.prettierOptions, parser: "json" }, "json"),
         },
       },
       {
@@ -311,8 +434,8 @@ export async function formatters(
           parser: parserPlain,
         },
         rules: {
-          ...turnOffRules,
-          ...fmtRule({ ...prettierOptions, parser: "jsonc" }, "json"),
+          ...turnOffRules(mut_resolved.json),
+          ...fmtRule(mut_resolved.json, { ...mut_resolved.json.prettierOptions, parser: "jsonc" }, "json"),
         },
       },
       {
@@ -322,8 +445,8 @@ export async function formatters(
           parser: parserPlain,
         },
         rules: {
-          ...turnOffRules,
-          ...fmtRule({ ...prettierOptions, parser: "json5" }, "json"),
+          ...turnOffRules(mut_resolved.json),
+          ...fmtRule(mut_resolved.json, { ...mut_resolved.json.prettierOptions, parser: "json5" }, "json"),
         },
       },
       {
@@ -391,7 +514,7 @@ export async function formatters(
     );
   }
 
-  if (options.css) {
+  if (mut_resolved.css.enabled) {
     mut_configs.push(
       {
         name: "rs:formatter:css",
@@ -400,8 +523,8 @@ export async function formatters(
           parser: parserPlain,
         },
         rules: {
-          ...turnOffRules,
-          ...fmtRule({ ...prettierOptions, parser: "css" }, "css"),
+          ...turnOffRules(mut_resolved.css),
+          ...fmtRule(mut_resolved.css, { ...mut_resolved.css.prettierOptions, parser: "css" }, "css"),
         },
       },
       {
@@ -411,8 +534,8 @@ export async function formatters(
           parser: parserPlain,
         },
         rules: {
-          ...turnOffRules,
-          ...fmtRule({ ...prettierOptions, parser: "scss" }, "css"),
+          ...turnOffRules(mut_resolved.css),
+          ...fmtRule(mut_resolved.css, { ...mut_resolved.css.prettierOptions, parser: "scss" }, "css"),
         },
       },
       {
@@ -422,14 +545,14 @@ export async function formatters(
           parser: parserPlain,
         },
         rules: {
-          ...turnOffRules,
-          ...fmtRule({ ...prettierOptions, parser: "less" }, "css"),
+          ...turnOffRules(mut_resolved.css),
+          ...fmtRule(mut_resolved.css, { ...mut_resolved.css.prettierOptions, parser: "less" }, "css"),
         },
       },
     );
   }
 
-  if (options.html) {
+  if (mut_resolved.html.enabled) {
     mut_configs.push({
       name: "rs:formatter:html",
       files: ["**/*.html"],
@@ -437,15 +560,19 @@ export async function formatters(
         parser: parserPlain,
       },
       rules: {
-        ...turnOffRules,
-        ...fmtRule({ ...prettierOptions, parser: "html" }, "html"),
+        ...turnOffRules(mut_resolved.html),
+        ...fmtRule(mut_resolved.html, { ...mut_resolved.html.prettierOptions, parser: "html" }, "html"),
       },
     });
   }
 
-  if (options.markdown) {
+  if (mut_resolved.markdown.enabled) {
     const GLOB_SLIDEV =
-      options.slidev === false ? [] : options.slidev === true ? ["**/slides.md"] : (options.slidev.files ?? []);
+      !mut_resolved.slidev.enabled
+        ? []
+        : typeof options.slidev === "object" && options.slidev !== null
+          ? (options.slidev.files ?? [])
+          : ["**/slides.md"];
 
     mut_configs.push({
       name: "rs:formatter:markdown",
@@ -455,12 +582,20 @@ export async function formatters(
         parser: parserPlain,
       },
       rules: {
-        ...turnOffRules,
-        ...fmtRule({ ...prettierOptions, embeddedLanguageFormatting: "off", parser: "markdown" }, "markdown"),
+        ...turnOffRules(mut_resolved.markdown),
+        ...fmtRule(
+          mut_resolved.markdown,
+          {
+            ...mut_resolved.markdown.prettierOptions,
+            embeddedLanguageFormatting: "off",
+            parser: "markdown",
+          },
+          "markdown",
+        ),
       },
     });
 
-    if (options.slidev !== false) {
+    if (mut_resolved.slidev.enabled) {
       mut_configs.push({
         name: "rs:formatter:slidev",
         files: GLOB_SLIDEV,
@@ -468,10 +603,11 @@ export async function formatters(
           parser: parserPlain,
         },
         rules: {
-          ...turnOffRules,
+          ...turnOffRules(mut_resolved.slidev),
           ...fmtRule(
+            mut_resolved.slidev,
             {
-              ...prettierOptions,
+              ...mut_resolved.slidev.prettierOptions,
               embeddedLanguageFormatting: "off",
               parser: "slidev",
               plugins: ["prettier-plugin-slidev"],
@@ -483,7 +619,7 @@ export async function formatters(
     }
   }
 
-  if (options.graphql) {
+  if (mut_resolved.graphql.enabled) {
     mut_configs.push({
       files: [GLOB_GRAPHQL],
       languageOptions: {
@@ -491,8 +627,8 @@ export async function formatters(
       },
       name: "rs:formatter:graphql",
       rules: {
-        ...turnOffRules,
-        ...fmtRule({ ...prettierOptions, parser: "graphql" }, "graphql"),
+        ...turnOffRules(mut_resolved.graphql),
+        ...fmtRule(mut_resolved.graphql, { ...mut_resolved.graphql.prettierOptions, parser: "graphql" }, "graphql"),
       },
     });
   }

--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -70,6 +70,37 @@ type ResolvedFormatterCategory = {
 };
 
 /**
+ * Every formatter category, fully resolved against the top-level defaults.
+ */
+export type ResolvedFormatterCategories = {
+  js: ResolvedFormatterCategory;
+  ts: ResolvedFormatterCategory;
+  json: ResolvedFormatterCategory;
+  yaml: ResolvedFormatterCategory;
+  css: ResolvedFormatterCategory;
+  html: ResolvedFormatterCategory;
+  markdown: ResolvedFormatterCategory;
+  graphql: ResolvedFormatterCategory;
+  slidev: ResolvedFormatterCategory;
+};
+
+/**
+ * The shared resolution consumed by both `formatters()` and assembly:
+ * the resolved categories plus the derived option payloads `formatters()`
+ * builds its blocks from.
+ */
+export type FormatterCategoriesResolution = {
+  categories: ResolvedFormatterCategories;
+
+  /** User options merged over the `true` shorthand defaults. */
+  options: OptionsFormatters;
+
+  prettierOptions: PrettierOptions;
+  dprintOptions: DprintGlobalOptions;
+  dprintJsTsLanguageOptions: { quoteStyle: "alwaysSingle" | "alwaysDouble" };
+};
+
+/**
  * Resolve a single formatter category against the top-level defaults.
  *
  * Merge precedence: category object > top-level > `"prettier"`.
@@ -88,7 +119,13 @@ function resolveCategory(
   defaults: FormatterCategoryDefaults,
 ): ResolvedFormatterCategory {
   const enabled = value === undefined ? defaults.enabled : value !== false;
-  const category = typeof value === "object" && value !== null ? value : {};
+  // Plain-JS consumers get no type checking; a runtime `null` must degrade to `{}`.
+  const category =
+    typeof value === "object" &&
+    // eslint-disable-next-line ts/no-unnecessary-condition -- see above
+    value !== null
+      ? value
+      : {};
 
   // String shorthand (`"prettier"` | `"dprint"` | `"eslint"`) selects the formatter directly.
   const mut_rawFormatter: unknown =
@@ -138,31 +175,18 @@ function createFormatRule(
 }
 
 /**
- * Enable formatting via `eslint-plugin-format` for JS/TS, JSON, YAML,
- * CSS/SCSS/LESS, HTML, Markdown, GraphQL, and Tailwind files.
- *
- * Passing `true` enables all formatters and auto-detects slidev/tailwind
- * packages. Each file category independently selects its underlying formatter
- * (`"prettier"` or `"dprint"`; `"eslint"` is additionally accepted for
- * `js`/`ts`), falling back to the top-level `formatter` (default
- * `"prettier"`). When a js/ts category selects `"eslint"`, that block skips
- * the external formatter entirely and instead registers `@stylistic` with a
- * relaxed rule map approximating prettier style (no reflow, no line-length
- * enforcement). Non-JS file types use `parserPlain`; `stylistic` drives
- * printWidth/quotes/semi. Throws if `slidev` is enabled without `markdown`.
- *
- * When an object is passed, any unspecified per-language flag inherits the
- * same defaults as passing `true` (all enabled except `dts`), so partial
- * objects behave symmetrically with the `true` shorthand.
+ * Resolve every formatter category against the top-level defaults — the single
+ * source of truth shared by `formatters()` and assembly (which needs the
+ * resolved js/ts backends to decide stylistic-item suppression).
  *
  * @param optionsInput - Formatter toggles, or `true` to enable all
  * @param stylistic - Stylistic config controlling printWidth/quotes/semi
- * @returns Flat config items enabling formatting per file type
+ * @returns The resolved categories and derived option payloads
  */
-export async function formatters(
+export function resolveFormatterCategories(
   optionsInput: Readonly<OptionsFormatters | true>,
   stylistic: Readonly<StylisticConfig>,
-): Promise<FlatConfigItem[]> {
+): FormatterCategoriesResolution {
   const formatterDefaults = {
     js: true,
     ts: true,
@@ -178,7 +202,8 @@ export async function formatters(
     formatter: "prettier" as const,
   };
 
-  const options = optionsInput === true ? { ...formatterDefaults } : { ...formatterDefaults, ...optionsInput };
+  const options: OptionsFormatters =
+    optionsInput === true ? { ...formatterDefaults } : { ...formatterDefaults, ...optionsInput };
 
   const { indent, printWidth, quotes, semi } = stylistic;
 
@@ -218,7 +243,7 @@ export async function formatters(
     ...options.dprintOptions,
   };
 
-  const dprintJsTsLanguageOptions = {
+  const dprintJsTsLanguageOptions: { quoteStyle: "alwaysSingle" | "alwaysDouble" } = {
     quoteStyle: quotes === "single" ? "alwaysSingle" : "alwaysDouble",
   };
 
@@ -228,7 +253,7 @@ export async function formatters(
     dprintOptions,
   };
 
-  const mut_resolved = {
+  const mut_resolved: ResolvedFormatterCategories = {
     js: resolveCategory("js", options.js, { ...topLevelDefaults, enabled: formatterDefaults.js }),
     ts: resolveCategory("ts", options.ts, { ...topLevelDefaults, enabled: formatterDefaults.ts }),
     json: resolveCategory("json", options.json, { ...topLevelDefaults, enabled: formatterDefaults.json }),
@@ -245,6 +270,51 @@ export async function formatters(
     }),
     slidev: resolveCategory("slidev", options.slidev, { ...topLevelDefaults, enabled: formatterDefaults.slidev }),
   };
+
+  return {
+    categories: mut_resolved,
+    options,
+    prettierOptions,
+    dprintOptions,
+    dprintJsTsLanguageOptions,
+  };
+}
+
+/**
+ * Enable formatting via `eslint-plugin-format` for JS/TS, JSON, YAML,
+ * CSS/SCSS/LESS, HTML, Markdown, GraphQL, and Tailwind files.
+ *
+ * Passing `true` enables all formatters and auto-detects slidev/tailwind
+ * packages. Each file category independently selects its underlying formatter
+ * (`"prettier"` or `"dprint"`; `"eslint"` is additionally accepted for
+ * `js`/`ts`), falling back to the top-level `formatter` (default
+ * `"prettier"`). When a js/ts category selects `"eslint"`, that block skips
+ * the external formatter entirely and instead registers `@stylistic` with a
+ * relaxed rule map approximating prettier style (no reflow, no line-length
+ * enforcement). Non-JS file types use `parserPlain`; `stylistic` drives
+ * printWidth/quotes/semi. Throws if `slidev` is enabled without `markdown`.
+ *
+ * When an object is passed, any unspecified per-language flag inherits the
+ * same defaults as passing `true` (all enabled except `dts`), so partial
+ * objects behave symmetrically with the `true` shorthand.
+ *
+ * @param optionsInput - Formatter toggles, or `true` to enable all
+ * @param stylistic - Stylistic config controlling printWidth/quotes/semi
+ * @param resolution - Pre-computed category resolution from
+ * `resolveFormatterCategories`; computed here when omitted so assembly and
+ * this function can share a single resolution.
+ * @returns Flat config items enabling formatting per file type
+ */
+export async function formatters(
+  optionsInput: Readonly<OptionsFormatters | true>,
+  stylistic: Readonly<StylisticConfig>,
+  resolution?: Readonly<FormatterCategoriesResolution>,
+): Promise<FlatConfigItem[]> {
+  const {
+    categories: mut_resolved,
+    options,
+    dprintJsTsLanguageOptions,
+  } = resolution ?? resolveFormatterCategories(optionsInput, stylistic);
 
   if (mut_resolved.slidev.enabled && !mut_resolved.markdown.enabled) {
     throw new Error("`slidev` option only works when `markdown` is enabled");
@@ -276,7 +346,8 @@ export async function formatters(
 
   const [mut_pluginFormat, mut_configPrettier, sortPackageJson, formattingReporter] = [
     packagesById.get("eslint-plugin-format") as ESLint.Plugin,
-    packagesById.get("eslint-config-prettier") as ESLint.ConfigData,
+    // Absent when no enabled category uses prettier/dprint (e.g. js/ts-only `"eslint"`).
+    packagesById.get("eslint-config-prettier") as ESLint.ConfigData | undefined,
     packagesById.get("sort-package-json") as (typeof import("sort-package-json"))["default"],
     packagesById.get("eslint-formatting-reporter") as typeof import("eslint-formatting-reporter"),
   ];
@@ -297,7 +368,7 @@ export async function formatters(
   // Rule offs derived from `eslint-config-prettier` plus rules whose concerns
   // are owned by prettier/dprint. Applied only to prettier/dprint-backed blocks.
   const prettierDerivedOffs = {
-    ...Object.fromEntries(Object.entries(mut_configPrettier.rules ?? {}).filter(([, value]) => value === "off")),
+    ...Object.fromEntries(Object.entries(mut_configPrettier?.rules ?? {}).filter(([, value]) => value === "off")),
 
     // curly: "off",
     "no-unexpected-multiline": "off",
@@ -389,7 +460,7 @@ export async function formatters(
               {
                 ...mut_resolved.js.prettierOptions,
                 parser: "babel",
-                ...(options.tailwind && {
+                ...(options.tailwind === true && {
                   plugins: mut_resolved.js.prettierOptions["plugins"] ?? [],
                 }),
               },
@@ -405,7 +476,7 @@ export async function formatters(
     mut_configs.push({
       name: "rs:formatter:typescript",
       files: [GLOB_TS, GLOB_TSX],
-      ignores: options.dts ? [] : [GLOB_DTS],
+      ignores: options.dts === true ? [] : [GLOB_DTS],
       ...(tsEslintBackend && {
         plugins: {
           "@stylistic": pluginStylistic as ESLint.Plugin,
@@ -424,7 +495,7 @@ export async function formatters(
               {
                 ...mut_resolved.ts.prettierOptions,
                 parser: "typescript",
-                ...(options.tailwind && {
+                ...(options.tailwind === true && {
                   plugins: mut_resolved.ts.prettierOptions["plugins"] ?? [],
                 }),
               },
@@ -603,8 +674,11 @@ export async function formatters(
   }
 
   if (mut_resolved.markdown.enabled) {
+    // Plain-JS consumers get no type checking; a runtime `null` must not crash.
     const GLOB_SLIDEV = mut_resolved.slidev.enabled
-      ? typeof options.slidev === "object" && options.slidev !== null
+      ? typeof options.slidev === "object" &&
+        // eslint-disable-next-line ts/no-unnecessary-condition -- see above
+        options.slidev !== null
         ? (options.slidev.files ?? [])
         : ["**/slides.md"]
       : [];

--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -303,12 +303,16 @@ export function resolveFormatterCategories(
  * @param resolution - Pre-computed category resolution from
  * `resolveFormatterCategories`; computed here when omitted so assembly and
  * this function can share a single resolution.
+ * @param cssInVue - Also emit formatter blocks for the virtual `<file>.vue/style.<lang>`
+ * files the vue SFC block processor creates; requires `vue.sfcBlocks` (default-on)
+ * and an enabled `css` category. Defaults to `false`.
  * @returns Flat config items enabling formatting per file type
  */
 export async function formatters(
   optionsInput: Readonly<OptionsFormatters | true>,
   stylistic: Readonly<StylisticConfig>,
   resolution?: Readonly<FormatterCategoriesResolution>,
+  cssInVue = false,
 ): Promise<FlatConfigItem[]> {
   const {
     categories: mut_resolved,
@@ -648,6 +652,50 @@ export async function formatters(
       {
         name: "rs:formatter:less",
         files: [GLOB_LESS],
+        languageOptions: {
+          parser: parserPlain,
+        },
+        rules: {
+          ...turnOffRules(mut_resolved.css),
+          ...fmtRule(mut_resolved.css, { ...mut_resolved.css.prettierOptions, parser: "less" }, "css"),
+        },
+      },
+    );
+  }
+
+  // Format `<style>` blocks inside Vue SFCs via the virtual files
+  // `eslint-processor-vue-blocks` emits (`<file>.vue/style.<lang>`, wired by
+  // the vue config when `vue.sfcBlocks` is enabled — its default). Requires
+  // both Vue support and an enabled `formatters.css` category; style blocks in
+  // languages without a parser mapping here (e.g. stylus, plain `sass`) are
+  // silently uncovered.
+  if (cssInVue && mut_resolved.css.enabled) {
+    mut_configs.push(
+      {
+        name: "rs:formatter:vue-style-css",
+        files: ["**/*.vue/style.css", "**/*.vue/style.pcss", "**/*.vue/style.postcss"],
+        languageOptions: {
+          parser: parserPlain,
+        },
+        rules: {
+          ...turnOffRules(mut_resolved.css),
+          ...fmtRule(mut_resolved.css, { ...mut_resolved.css.prettierOptions, parser: "css" }, "css"),
+        },
+      },
+      {
+        name: "rs:formatter:vue-style-scss",
+        files: ["**/*.vue/style.scss"],
+        languageOptions: {
+          parser: parserPlain,
+        },
+        rules: {
+          ...turnOffRules(mut_resolved.css),
+          ...fmtRule(mut_resolved.css, { ...mut_resolved.css.prettierOptions, parser: "scss" }, "css"),
+        },
+      },
+      {
+        name: "rs:formatter:vue-style-less",
+        files: ["**/*.vue/style.less"],
         languageOptions: {
           parser: parserPlain,
         },

--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -112,6 +112,7 @@ export type FormatterCategoriesResolution = {
  * @param defaults - Resolved top-level defaults for this category
  * @returns The resolved category
  * @throws {Error} When the `"eslint"` backend is selected for a category other than `js`/`ts`
+ * @throws {Error} When the resolved formatter is not `"prettier"`, `"dprint"`, or (for `js`/`ts`) `"eslint"`
  */
 function resolveCategory(
   key: string,
@@ -138,9 +139,23 @@ function resolveCategory(
     );
   }
 
+  if (
+    mut_rawFormatter !== undefined &&
+    mut_rawFormatter !== "prettier" &&
+    mut_rawFormatter !== "dprint" &&
+    mut_rawFormatter !== "eslint"
+  ) {
+    const expectedFormatters =
+      key === "js" || key === "ts" ? '`"prettier"`, `"dprint"`, or `"eslint"`' : '`"prettier"` or `"dprint"`';
+    // eslint-disable-next-line functional/no-throw-statements -- misconfiguration must fail loudly, not silently fall through
+    throw new Error(
+      `\`formatters.${key}\` received an unsupported formatter value: ${JSON.stringify(mut_rawFormatter)} - expected ${expectedFormatters}, or no formatter to inherit the top-level default.`,
+    );
+  }
+
   return {
     enabled,
-    formatter: mut_rawFormatter === "dprint" ? "dprint" : mut_rawFormatter === "eslint" ? "eslint" : "prettier",
+    formatter: mut_rawFormatter ?? "prettier",
     prettierOptions: { ...defaults.prettierOptions, ...category.prettierOptions },
     dprintOptions: { ...defaults.dprintOptions, ...category.dprintOptions },
     dprintPlugins: category.dprintPlugins,

--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -1,3 +1,4 @@
+import type { GlobalConfiguration } from "@dprint/formatter";
 import type { ESLint, Rule } from "eslint";
 import { isPackageExists } from "local-pkg";
 import type { Options as PrettierOptions } from "prettier";
@@ -27,6 +28,16 @@ import { StylisticConfigDefaults } from "./stylistic";
 type FormatterType = "prettier" | "dprint";
 
 /**
+ * Options accepted by `eslint-plugin-format`'s `format/dprint` rule:
+ * dprint global options plus the rule's language selector fields.
+ */
+type DprintFormatOptions = GlobalConfiguration & {
+  language: string;
+  languageOptions?: Record<string, unknown>;
+  plugins?: string[];
+};
+
+/**
  * Create a format rule for the given formatter type.
  *
  * @param formatter - Which formatter to use
@@ -40,20 +51,16 @@ function createFormatRule(
   formatter: FormatterType,
   prettierOpts: Record<string, unknown>,
   dprintLang: string,
-  dprintGlobalOpts: Record<string, unknown>,
+  dprintGlobalOpts: GlobalConfiguration,
   dprintLangOpts?: Record<string, unknown>,
 ): [string, unknown[]] {
   if (formatter === "dprint") {
-    return [
-      "format/dprint",
-      [
-        {
-          ...dprintGlobalOpts,
-          language: dprintLang,
-          ...(dprintLangOpts === undefined ? {} : { languageOptions: dprintLangOpts }),
-        },
-      ],
-    ] as [string, unknown[]];
+    const dprintOptions: DprintFormatOptions = {
+      ...dprintGlobalOpts,
+      language: dprintLang,
+      ...(dprintLangOpts === undefined ? {} : { languageOptions: dprintLangOpts }),
+    };
+    return ["format/dprint", [dprintOptions]];
   }
   return ["format/prettier", [prettierOpts]] as [string, unknown[]];
 }
@@ -67,6 +74,10 @@ function createFormatRule(
  * Non-JS file types use `parserPlain`; `stylistic` drives
  * printWidth/quotes/semi. Throws if `slidev` is enabled without `markdown`.
  *
+ * When an object is passed, any unspecified per-language flag inherits the
+ * same defaults as passing `true` (all enabled except `dts`), so partial
+ * objects behave symmetrically with the `true` shorthand.
+ *
  * @param optionsInput - Formatter toggles, or `true` to enable all
  * @param stylistic - Stylistic config controlling printWidth/quotes/semi
  * @returns Flat config items enabling formatting per file type
@@ -75,25 +86,24 @@ export async function formatters(
   optionsInput: Readonly<OptionsFormatters | true>,
   stylistic: Readonly<StylisticConfig>,
 ): Promise<FlatConfigItem[]> {
-  const options =
-    optionsInput === true
-      ? {
-          js: true,
-          ts: true,
-          dts: false,
-          json: true,
-          yaml: true,
-          css: true,
-          graphql: true,
-          html: true,
-          markdown: true,
-          slidev: isPackageExists("@slidev/cli"),
-          tailwind: isPackageExists("tailwindcss"),
-          formatter: "prettier" as const,
-        }
-      : { formatter: "prettier" as const, ...optionsInput };
+  const formatterDefaults = {
+    js: true,
+    ts: true,
+    dts: false,
+    json: true,
+    yaml: true,
+    css: true,
+    graphql: true,
+    html: true,
+    markdown: true,
+    slidev: isPackageExists("@slidev/cli"),
+    tailwind: isPackageExists("tailwindcss"),
+    formatter: "prettier" as const,
+  };
 
-  if (options.slidev !== false && options.slidev !== undefined && options.markdown !== true) {
+  const options = optionsInput === true ? { ...formatterDefaults } : { ...formatterDefaults, ...optionsInput };
+
+  if (options.slidev !== false && !options.markdown) {
     throw new Error("`slidev` option only works when `markdown` is enabled");
   }
 
@@ -121,7 +131,10 @@ export async function formatters(
     options.prettierOptions ?? {},
   );
 
-  const dprintOptions: Record<string, unknown> = {
+  // `semiColons` is plugin-scoped in dprint, but eslint-plugin-format merges global and
+  // language options before handing them to the plugin; passing it globally avoids the
+  // trailing-separator behavior inside single-line type literals.
+  const dprintOptions: GlobalConfiguration & { semiColons?: "asi" | "always" } = {
     indentWidth:
       typeof indent === "number"
         ? indent
@@ -130,13 +143,13 @@ export async function formatters(
           : 2,
     lineWidth: printWidth ?? 120,
     newLineKind: "lf",
+    semiColons: semi === false ? "asi" : "always",
     useTabs: indent === "tab",
     ...options.dprintOptions,
   };
 
   const dprintJsTsLanguageOptions = {
     quoteStyle: quotes === "single" ? "alwaysSingle" : "alwaysDouble",
-    semiColons: semi === false ? "asi" : "always",
   };
 
   const packages = (await loadPackages([
@@ -184,6 +197,15 @@ export async function formatters(
     // other
     "no-irregular-whitespace": "off",
     "yml/block-sequence-hyphen-indicator-newline": "off",
+
+    // dprint controls operator line-break positioning and ternary layout.
+    ...(useDprint && {
+      "@stylistic/operator-linebreak": "off",
+      "unicorn/no-nested-ternary": "off",
+      // dprint controls import member and declaration ordering.
+      "import-x/order": "off",
+      "sort-imports": "off",
+    }),
   } satisfies FlatConfigItem["rules"];
 
   // Shorthand: create format rule with current formatter.
@@ -211,7 +233,7 @@ export async function formatters(
     },
   ];
 
-  if (options.js !== undefined && options.js) {
+  if (options.js) {
     mut_configs.push({
       name: "rs:formatter:javascript",
       files: [GLOB_JS, GLOB_JSX],
@@ -221,10 +243,9 @@ export async function formatters(
           {
             ...prettierOptions,
             parser: "babel",
-            ...(options.tailwind !== undefined &&
-              options.tailwind && {
-                plugins: prettierOptions.plugins ?? [],
-              }),
+            ...(options.tailwind && {
+              plugins: prettierOptions.plugins ?? [],
+            }),
           },
           "typescript",
           dprintJsTsLanguageOptions,
@@ -233,21 +254,20 @@ export async function formatters(
     });
   }
 
-  if (options.ts !== undefined && options.ts) {
+  if (options.ts) {
     mut_configs.push({
       name: "rs:formatter:typescript",
       files: [GLOB_TS, GLOB_TSX],
-      ignores: options.dts === true ? [] : [GLOB_DTS],
+      ignores: options.dts ? [] : [GLOB_DTS],
       rules: {
         ...turnOffRules,
         ...fmtRule(
           {
             ...prettierOptions,
             parser: "typescript",
-            ...(options.tailwind !== undefined &&
-              options.tailwind && {
-                plugins: prettierOptions.plugins ?? [],
-              }),
+            ...(options.tailwind && {
+              plugins: prettierOptions.plugins ?? [],
+            }),
           },
           "typescript",
           dprintJsTsLanguageOptions,
@@ -256,7 +276,7 @@ export async function formatters(
     });
   }
 
-  if (options.yaml !== undefined && options.yaml) {
+  if (options.yaml) {
     mut_configs.push({
       name: "rs:formatter:yaml",
       files: [GLOB_YAML],
@@ -270,7 +290,7 @@ export async function formatters(
     });
   }
 
-  if (options.json !== undefined && options.json) {
+  if (options.json) {
     mut_configs.push(
       {
         name: "rs:formatter:json",
@@ -371,7 +391,7 @@ export async function formatters(
     );
   }
 
-  if (options.css !== undefined && options.css) {
+  if (options.css) {
     mut_configs.push(
       {
         name: "rs:formatter:css",
@@ -409,7 +429,7 @@ export async function formatters(
     );
   }
 
-  if (options.html !== undefined && options.html) {
+  if (options.html) {
     mut_configs.push({
       name: "rs:formatter:html",
       files: ["**/*.html"],
@@ -423,13 +443,9 @@ export async function formatters(
     });
   }
 
-  if (options.markdown !== undefined && options.markdown) {
+  if (options.markdown) {
     const GLOB_SLIDEV =
-      options.slidev === undefined || options.slidev === false
-        ? []
-        : options.slidev === true
-          ? ["**/slides.md"]
-          : (options.slidev.files ?? []);
+      options.slidev === false ? [] : options.slidev === true ? ["**/slides.md"] : (options.slidev.files ?? []);
 
     mut_configs.push({
       name: "rs:formatter:markdown",
@@ -444,7 +460,7 @@ export async function formatters(
       },
     });
 
-    if (options.slidev !== undefined && options.slidev !== false) {
+    if (options.slidev !== false) {
       mut_configs.push({
         name: "rs:formatter:slidev",
         files: GLOB_SLIDEV,
@@ -467,7 +483,7 @@ export async function formatters(
     }
   }
 
-  if (options.graphql !== undefined && options.graphql) {
+  if (options.graphql) {
     mut_configs.push({
       files: [GLOB_GRAPHQL],
       languageOptions: {

--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -29,6 +29,7 @@ import type {
 } from "../types";
 import { loadPackages, parserPlain } from "../utils";
 
+import { eslintFormatterStylisticRules } from "./eslint-formatter";
 import { StylisticConfigDefaults } from "./stylistic";
 
 /**
@@ -62,7 +63,7 @@ type FormatterCategoryDefaults = {
  */
 type ResolvedFormatterCategory = {
   enabled: boolean;
-  formatter: FormatterType;
+  formatter: FormatterType | "eslint";
   prettierOptions: Record<string, unknown>;
   dprintOptions: DprintGlobalOptions;
   dprintPlugins: string[] | undefined;
@@ -79,6 +80,7 @@ type ResolvedFormatterCategory = {
  * @param value - User-supplied category value (boolean / string / object)
  * @param defaults - Resolved top-level defaults for this category
  * @returns The resolved category
+ * @throws {Error} When the `"eslint"` backend is selected for a category other than `js`/`ts`
  */
 function resolveCategory(
   key: string,
@@ -93,6 +95,7 @@ function resolveCategory(
     category.formatter ?? (typeof value === "string" ? value : undefined) ?? defaults.formatter;
 
   if (mut_rawFormatter === "eslint" && key !== "js" && key !== "ts") {
+    // eslint-disable-next-line functional/no-throw-statements -- misconfiguration must fail loudly, not silently fall through
     throw new Error(
       `\`formatters.${key}\` does not support the \`"eslint"\` formatter backend - only the \`js\` and \`ts\` categories do.`,
     );
@@ -100,7 +103,7 @@ function resolveCategory(
 
   return {
     enabled,
-    formatter: mut_rawFormatter === "dprint" ? "dprint" : "prettier",
+    formatter: mut_rawFormatter === "dprint" ? "dprint" : mut_rawFormatter === "eslint" ? "eslint" : "prettier",
     prettierOptions: { ...defaults.prettierOptions, ...category.prettierOptions },
     dprintOptions: { ...defaults.dprintOptions, ...category.dprintOptions },
     dprintPlugins: category.dprintPlugins,
@@ -142,7 +145,10 @@ function createFormatRule(
  * packages. Each file category independently selects its underlying formatter
  * (`"prettier"` or `"dprint"`; `"eslint"` is additionally accepted for
  * `js`/`ts`), falling back to the top-level `formatter` (default
- * `"prettier"`). Non-JS file types use `parserPlain`; `stylistic` drives
+ * `"prettier"`). When a js/ts category selects `"eslint"`, that block skips
+ * the external formatter entirely and instead registers `@stylistic` with a
+ * relaxed rule map approximating prettier style (no reflow, no line-length
+ * enforcement). Non-JS file types use `parserPlain`; `stylistic` drives
  * printWidth/quotes/semi. Throws if `slidev` is enabled without `markdown`.
  *
  * When an object is passed, any unspecified per-language flag inherits the
@@ -246,20 +252,20 @@ export async function formatters(
 
   const formattingCategories = Object.values(mut_resolved);
 
-  if (!formattingCategories.some((category) => category.enabled)) {
+  if (formattingCategories.every((category) => !category.enabled)) {
     return [];
   }
 
-  const needsPrettier = formattingCategories.some(
-    (category) => category.enabled && category.formatter === "prettier",
-  );
-  const needsDprint = formattingCategories.some(
-    (category) => category.enabled && category.formatter === "dprint",
+  const needsPrettier = formattingCategories.some((category) => category.enabled && category.formatter === "prettier");
+  const needsDprint = formattingCategories.some((category) => category.enabled && category.formatter === "dprint");
+  const needsStylisticPlugin = formattingCategories.some(
+    (category) => category.enabled && category.formatter === "eslint",
   );
 
   const neededPackageIds = [
     "eslint-plugin-format",
     ...(needsPrettier || needsDprint ? ["eslint-config-prettier"] : []),
+    ...(needsStylisticPlugin ? ["@stylistic/eslint-plugin"] : []),
     "sort-package-json",
     "eslint-formatting-reporter",
     ...(needsPrettier ? ["prettier"] : []),
@@ -274,6 +280,12 @@ export async function formatters(
     packagesById.get("sort-package-json") as (typeof import("sort-package-json"))["default"],
     packagesById.get("eslint-formatting-reporter") as typeof import("eslint-formatting-reporter"),
   ];
+
+  // Defined when a js/ts category selects the `"eslint"` backend; the same
+  // memoized module instance `stylistic()` uses (ESM cache + loadPackages
+  // memoization), so dual registration is safe.
+  const pluginStylistic = packagesById.get("@stylistic/eslint-plugin") as
+    (typeof import("@stylistic/eslint-plugin"))["default"] | undefined;
 
   // Backend-independent rule offs, applied to every formatter block no matter
   // which formatter backs it.
@@ -355,47 +367,71 @@ export async function formatters(
   ];
 
   if (mut_resolved.js.enabled) {
+    const jsEslintBackend = mut_resolved.js.formatter === "eslint";
     mut_configs.push({
       name: "rs:formatter:javascript",
       files: [GLOB_JS, GLOB_JSX],
-      rules: {
-        ...turnOffRules(mut_resolved.js),
-        ...fmtRule(
-          mut_resolved.js,
-          {
-            ...mut_resolved.js.prettierOptions,
-            parser: "babel",
-            ...(options.tailwind && {
-              plugins: mut_resolved.js.prettierOptions["plugins"] ?? [],
-            }),
+      ...(jsEslintBackend && {
+        plugins: {
+          "@stylistic": pluginStylistic as ESLint.Plugin,
+        },
+      }),
+      rules: jsEslintBackend
+        ? {
+            // D6: backend-independent offs apply everywhere, backend included.
+            ...backendIndependentOffs,
+            ...(await eslintFormatterStylisticRules({ stylistic, typescript: false })),
+          }
+        : {
+            ...turnOffRules(mut_resolved.js),
+            ...fmtRule(
+              mut_resolved.js,
+              {
+                ...mut_resolved.js.prettierOptions,
+                parser: "babel",
+                ...(options.tailwind && {
+                  plugins: mut_resolved.js.prettierOptions["plugins"] ?? [],
+                }),
+              },
+              "typescript",
+              dprintJsTsLanguageOptions,
+            ),
           },
-          "typescript",
-          dprintJsTsLanguageOptions,
-        ),
-      },
     });
   }
 
   if (mut_resolved.ts.enabled) {
+    const tsEslintBackend = mut_resolved.ts.formatter === "eslint";
     mut_configs.push({
       name: "rs:formatter:typescript",
       files: [GLOB_TS, GLOB_TSX],
       ignores: options.dts ? [] : [GLOB_DTS],
-      rules: {
-        ...turnOffRules(mut_resolved.ts),
-        ...fmtRule(
-          mut_resolved.ts,
-          {
-            ...mut_resolved.ts.prettierOptions,
-            parser: "typescript",
-            ...(options.tailwind && {
-              plugins: mut_resolved.ts.prettierOptions["plugins"] ?? [],
-            }),
+      ...(tsEslintBackend && {
+        plugins: {
+          "@stylistic": pluginStylistic as ESLint.Plugin,
+        },
+      }),
+      rules: tsEslintBackend
+        ? {
+            // D6: backend-independent offs apply everywhere, backend included.
+            ...backendIndependentOffs,
+            ...(await eslintFormatterStylisticRules({ stylistic, typescript: true })),
+          }
+        : {
+            ...turnOffRules(mut_resolved.ts),
+            ...fmtRule(
+              mut_resolved.ts,
+              {
+                ...mut_resolved.ts.prettierOptions,
+                parser: "typescript",
+                ...(options.tailwind && {
+                  plugins: mut_resolved.ts.prettierOptions["plugins"] ?? [],
+                }),
+              },
+              "typescript",
+              dprintJsTsLanguageOptions,
+            ),
           },
-          "typescript",
-          dprintJsTsLanguageOptions,
-        ),
-      },
     });
   }
 
@@ -567,12 +603,11 @@ export async function formatters(
   }
 
   if (mut_resolved.markdown.enabled) {
-    const GLOB_SLIDEV =
-      !mut_resolved.slidev.enabled
-        ? []
-        : typeof options.slidev === "object" && options.slidev !== null
-          ? (options.slidev.files ?? [])
-          : ["**/slides.md"];
+    const GLOB_SLIDEV = mut_resolved.slidev.enabled
+      ? typeof options.slidev === "object" && options.slidev !== null
+        ? (options.slidev.files ?? [])
+        : ["**/slides.md"]
+      : [];
 
     mut_configs.push({
       name: "rs:formatter:markdown",

--- a/src/configs/formatters.ts
+++ b/src/configs/formatters.ts
@@ -678,12 +678,18 @@ export async function formatters(
     );
   }
 
-  // Format `<style>` blocks inside Vue SFCs via the virtual files
-  // `eslint-processor-vue-blocks` emits (`<file>.vue/style.<lang>`, wired by
-  // the vue config when `vue.sfcBlocks` is enabled — its default). Requires
-  // both Vue support and an enabled `formatters.css` category; style blocks in
-  // languages without a parser mapping here (e.g. stylus, plain `sass`) are
-  // silently uncovered.
+  /**
+   * Format `<style>` blocks inside Vue SFCs via the virtual files
+   * `eslint-processor-vue-blocks` emits (`<file>.vue/style.<lang>`, wired by
+   * the vue config when `vue.sfcBlocks` is enabled — its default). Requires
+   * both Vue support and an enabled `formatters.css` category; style blocks in
+   * languages without a parser mapping here (e.g. stylus, plain `sass`) are
+   * silently uncovered.
+   *
+   * Edge case: these globs match the processor's virtual output; a real
+   * on-disk path literally shaped like `*.vue/style.css` would also match.
+   * That is pathological and accepted — formatter rules are harmless there.
+   */
   if (cssInVue && mut_resolved.css.enabled) {
     mut_configs.push(
       {

--- a/src/configs/jsonc.ts
+++ b/src/configs/jsonc.ts
@@ -126,8 +126,9 @@ const TSCONFIG_SORT_COMPILER_OPTIONS = [
  * `valid-json-number`). Stylistic rules like `indent`, `quotes`, and `comma-dangle` are
  * enabled only when `stylistic` is not `false`.
  *
- * When TypeScript is available and stylistic is enabled, also enforces tsconfig.json key ordering
- * via `jsonc/sort-keys`.
+ * When TypeScript is available, also enforces tsconfig.json key ordering
+ * via `jsonc/sort-keys` (independent of the `stylistic` option — key
+ * ordering is consistency, not styling).
  *
  * @param options - Options with `files`, `overrides`, `stylistic`, and `typescript`
  * @returns Flat config items enabling jsonc rules
@@ -219,8 +220,9 @@ export async function jsonc(
       },
     },
 
-    // Sort tsconfig.json when TypeScript is available and formatting is enabled.
-    ...(typescript && stylistic !== false
+    // Sort tsconfig.json keys whenever TypeScript is available — key ordering
+    // is consistency, not styling, so this stays independent of `stylistic`.
+    ...(typescript
       ? [
           {
             files: ["**/tsconfig.json", "**/tsconfig.*.json"],

--- a/src/configs/stylistic-rules.ts
+++ b/src/configs/stylistic-rules.ts
@@ -1,0 +1,405 @@
+import type { StylisticCustomizeOptions } from "@stylistic/eslint-plugin";
+
+import type { FlatConfigItem, StylisticConfig } from "../types";
+import { loadPackages } from "../utils";
+
+/**
+ * Trailing comma behavior for a single comma-dangle context.
+ */
+type StylisticCommaDanglePerTypeValue = "always" | "always-multiline" | "never" | "only-multiline" | "ignore";
+
+/**
+ * The `comma-dangle` option: either a single value applied to every context,
+ * or per-context values (including the `@stylistic`-only TypeScript contexts).
+ */
+export type StylisticCommaDangleOption =
+  | Exclude<StylisticCommaDanglePerTypeValue, "ignore">
+  | Partial<
+      Record<
+        | "arrays"
+        | "objects"
+        | "imports"
+        | "exports"
+        | "functions"
+        | "enums"
+        | "generics"
+        | "tuples"
+        | "dynamicImports"
+        | "importAttributes",
+        StylisticCommaDanglePerTypeValue
+      >
+    >;
+
+/**
+ * Explicit knobs for each point where two stylistic profiles must diverge.
+ *
+ * Every knob defaults to the value that reproduces the historical
+ * `stylistic()` output exactly; the `"eslint"` formatter backend overrides
+ * only the knobs it needs (see `eslint-formatter.ts`).
+ */
+export type StylisticRulesProfile = {
+  /**
+   * Enable `@stylistic/indent` for TypeScript code (with TS-aware offsets:
+   * function return types, union/intersection `ignoredNodes`, and ternary
+   * offsets around calls/awaits/news).
+   *
+   * Has no effect when `typescript` is `false` (indent is always on there).
+   *
+   * @default false
+   */
+  indentTs?: boolean;
+
+  /**
+   * Keep `newline-per-chained-call` enforcement (chain breaks by depth).
+   *
+   * @default true
+   */
+  forceChainBreaks?: boolean;
+
+  /**
+   * Keep forced object newlines (`object-curly-newline` with
+   * `minProperties: 3` thresholds). When `false`, only `{ consistent: true }`
+   * is required.
+   *
+   * @default true
+   */
+  forceObjectNewlines?: boolean;
+
+  /**
+   * Keep `max-statements-per-line` enforcement.
+   *
+   * @default true
+   */
+  enforceMaxStatementsPerLine?: boolean;
+
+  /**
+   * The `multiline-ternary` mode. Note: no rule force-breaks *nested*
+   * ternaries; this is a documented gap of the rule ecosystem.
+   *
+   * @default "always-multiline"
+   */
+  ternaryMode?: "always" | "always-multiline" | "never";
+
+  /**
+   * The `comma-dangle` option. Defaults to the per-context map used by
+   * `stylistic()` (with the TypeScript contexts added when `typescript` is
+   * enabled).
+   */
+  commaDangle?: StylisticCommaDangleOption;
+};
+
+/**
+ * Options for `buildStylisticRules`.
+ */
+export type StylisticRulesOptions = {
+  /** Indent style/width forwarded to `@stylistic` rules. */
+  indent?: StylisticConfig["indent"] | undefined;
+
+  /** Whether JSX stylistic rules are included. */
+  jsx?: StylisticConfig["jsx"] | undefined;
+
+  /**
+   * Print width. Accepted for interface completeness; no rule consumes it
+   * because neither profile enforces line length.
+   */
+  printWidth?: StylisticConfig["printWidth"] | undefined;
+
+  /** Quote style forwarded to `@stylistic/quotes`. */
+  quotes?: StylisticConfig["quotes"] | undefined;
+
+  /** Whether semicolons are required. */
+  semi?: StylisticConfig["semi"] | undefined;
+
+  /** Whether TypeScript syntax is being linted. */
+  typescript?: boolean | undefined;
+
+  /** Profile knobs controlling the divergence points between profiles. */
+  profile?: StylisticRulesProfile | undefined;
+};
+
+// Local fallbacks mirroring `StylisticConfigDefaults` (duplicated here instead
+// of imported to keep this module free of cycles with `stylistic.ts`, which
+// consumes this builder).
+const DEFAULT_INDENT: NonNullable<StylisticConfig["indent"]> = 2;
+const DEFAULT_JSX = true;
+const DEFAULT_QUOTES = "double";
+const DEFAULT_SEMI = true;
+
+/**
+ * Build the shared `@stylistic/*` rule map consumed by both `stylistic()`
+ * and the `"eslint"` formatter backend.
+ *
+ * With default profile values the returned map is rule-for-rule identical to
+ * what `stylistic()` emits: it spreads the same `configs.customize(...)` base
+ * and then applies the same explicit rule entries on top, so later keys win
+ * in exactly the same way. Divergences are expressed exclusively through the
+ * `StylisticRulesProfile` knobs.
+ *
+ * @param options - Stylistic values, TypeScript flag, and profile knobs.
+ * @returns The `@stylistic/*` rule map.
+ */
+export async function buildStylisticRules(options: Readonly<StylisticRulesOptions>): Promise<FlatConfigItem["rules"]> {
+  const {
+    indent = DEFAULT_INDENT,
+    jsx = DEFAULT_JSX,
+    quotes = DEFAULT_QUOTES,
+    semi = DEFAULT_SEMI,
+    typescript,
+    profile = {},
+  } = options;
+
+  const [pluginStylistic] = (await loadPackages(["@stylistic/eslint-plugin"])) as [
+    typeof import("@stylistic/eslint-plugin").default,
+  ];
+
+  const config = pluginStylistic.configs.customize({
+    flat: true,
+    indent,
+    jsx,
+    pluginName: "@stylistic",
+    quotes,
+    semi,
+  } as StylisticCustomizeOptions);
+
+  const enableIndentTs = typescript === true && profile.indentTs === true;
+
+  return {
+    ...config.rules,
+
+    "@stylistic/array-bracket-spacing": ["error", "never"],
+    "@stylistic/arrow-parens": ["error", "always"],
+    "@stylistic/arrow-spacing": ["error", { before: true, after: true }],
+    "@stylistic/block-spacing": ["error", "always"],
+    "@stylistic/brace-style": "error",
+    "@stylistic/comma-dangle": [
+      "error",
+      profile.commaDangle ?? {
+        arrays: "only-multiline",
+        exports: "only-multiline",
+        functions: "ignore",
+        imports: "only-multiline",
+        objects: "only-multiline",
+
+        ...(typescript === true
+          ? {
+              enums: "only-multiline",
+              generics: "only-multiline",
+              tuples: "only-multiline",
+            }
+          : {}),
+      },
+    ],
+    "@stylistic/comma-spacing": ["error", { before: false, after: true }],
+    "@stylistic/comma-style": ["error", "last"],
+    "@stylistic/computed-property-spacing": "error",
+    "@stylistic/dot-location": ["error", "property"],
+    "@stylistic/eol-last": "error",
+    "@stylistic/function-call-spacing": ["error", "never"],
+    "@stylistic/generator-star-spacing": ["error", "after"],
+    "@stylistic/indent":
+      typescript !== true || enableIndentTs
+        ? [
+            "error",
+            indent,
+            enableIndentTs
+              ? {
+                  SwitchCase: 1,
+                  VariableDeclarator: 1,
+                  outerIIFEBody: 1,
+                  MemberExpression: 1,
+                  FunctionDeclaration: { parameters: 1, body: 1, returnType: 1 },
+                  FunctionExpression: { parameters: 1, body: 1, returnType: 1 },
+                  CallExpression: { arguments: 1 },
+                  ArrayExpression: 1,
+                  ObjectExpression: 1,
+                  ImportDeclaration: 1,
+                  flatTernaryExpressions: false,
+                  ignoreComments: false,
+                  ignoredNodes: ["TSUnionType", "TSIntersectionType"],
+                  offsetTernaryExpressions: {
+                    CallExpression: true,
+                    AwaitExpression: true,
+                    NewExpression: true,
+                  },
+                }
+              : {
+                  SwitchCase: 1,
+                  VariableDeclarator: 1,
+                  outerIIFEBody: 1,
+                  MemberExpression: 1,
+                  FunctionDeclaration: { parameters: 1, body: 1 },
+                  FunctionExpression: { parameters: 1, body: 1 },
+                  CallExpression: { arguments: 1 },
+                  ArrayExpression: 1,
+                  ObjectExpression: 1,
+                  ImportDeclaration: 1,
+                  flatTernaryExpressions: false,
+                  ignoreComments: false,
+                },
+          ]
+        : "off",
+    "@stylistic/indent-binary-ops": "error",
+    "@stylistic/key-spacing": ["error", { beforeColon: false, afterColon: true }],
+    "@stylistic/keyword-spacing": ["error", { before: true, after: true }],
+    "@stylistic/linebreak-style": ["error", "unix"],
+    "@stylistic/lines-around-comment": [
+      "warn",
+      {
+        beforeBlockComment: true,
+        beforeLineComment: false,
+        afterBlockComment: false,
+        afterLineComment: false,
+        afterHashbangComment: true,
+        allowBlockStart: true,
+        allowBlockEnd: true,
+        allowObjectStart: true,
+        allowObjectEnd: true,
+        allowArrayStart: true,
+        allowArrayEnd: true,
+        allowClassStart: true,
+        allowClassEnd: true,
+
+        ...(typescript === true
+          ? {
+              allowEnumEnd: true,
+              allowEnumStart: true,
+              allowInterfaceEnd: true,
+              allowInterfaceStart: true,
+              allowModuleEnd: true,
+              allowModuleStart: true,
+              allowTypeEnd: true,
+              allowTypeStart: true,
+            }
+          : {}),
+      },
+    ],
+    "@stylistic/lines-between-class-members": [
+      "error",
+      "always",
+      {
+        exceptAfterSingleLine: true,
+        ...(typescript === true
+          ? {
+              exceptAfterOverload: true,
+            }
+          : {}),
+      },
+    ],
+    "@stylistic/max-statements-per-line": profile.enforceMaxStatementsPerLine === false ? "off" : ["error", { max: 1 }],
+    "@stylistic/multiline-ternary": ["error", profile.ternaryMode ?? "always-multiline"],
+    "@stylistic/new-parens": "error",
+    "@stylistic/newline-per-chained-call":
+      profile.forceChainBreaks === false ? "off" : ["error", { ignoreChainWithDepth: 2 }],
+    "@stylistic/no-extra-parens": ["error", "all", { nestedBinaryExpressions: false }],
+    "@stylistic/no-extra-semi": "error",
+    "@stylistic/no-floating-decimal": "error",
+    "@stylistic/no-mixed-operators": [
+      "error",
+      {
+        groups: [
+          ["+", "-", "*", "/", "%", "**"],
+          ["&", "|", "^", "~", "<<", ">>", ">>>"],
+          ["==", "!=", "===", "!==", ">", ">=", "<", "<="],
+          ["&&", "||"],
+          ["in", "instanceof"],
+        ],
+        allowSamePrecedence: true,
+      },
+    ],
+    "@stylistic/no-mixed-spaces-and-tabs": "error",
+    "@stylistic/no-multi-spaces": ["error", { ignoreEOLComments: true }],
+    "@stylistic/no-multiple-empty-lines": ["error", { max: 1, maxEOF: 1 }],
+    "@stylistic/no-tabs": "error",
+    "@stylistic/no-trailing-spaces": "error",
+    "@stylistic/no-whitespace-before-property": "error",
+    "@stylistic/nonblock-statement-body-position": ["error", "beside", { overrides: {} }],
+    "@stylistic/object-curly-newline":
+      profile.forceObjectNewlines === false
+        ? ["error", { consistent: true }]
+        : [
+            "error",
+            {
+              ObjectExpression: {
+                minProperties: 3,
+                multiline: true,
+                consistent: true,
+              },
+              ObjectPattern: {
+                minProperties: 3,
+                multiline: true,
+                consistent: true,
+              },
+            },
+          ],
+    "@stylistic/object-curly-spacing": ["error", "always"],
+    "@stylistic/object-property-newline": ["error", { allowAllPropertiesOnSameLine: true }],
+    "@stylistic/one-var-declaration-per-line": ["error", "always"],
+    "@stylistic/operator-linebreak": [
+      "error",
+      "after",
+      {
+        overrides: {
+          // "=": "none",
+          "==": "none",
+          "===": "none",
+          "?": "before",
+          ":": "before",
+          "|": "before",
+        },
+      },
+    ],
+    "@stylistic/padded-blocks": [
+      "error",
+      {
+        blocks: "never",
+        switches: "never",
+        classes: "never",
+      },
+    ],
+    "@stylistic/quote-props": ["error", "consistent-as-needed"],
+    "@stylistic/quotes": ["error", quotes, { avoidEscape: true, allowTemplateLiterals: "never" }],
+    "@stylistic/rest-spread-spacing": ["error", "never"],
+    "@stylistic/semi-spacing": ["error", { before: false, after: true }],
+    "@stylistic/semi-style": ["error", "last"],
+    "@stylistic/semi": ["error", semi ? "always" : "never"],
+    "@stylistic/space-before-blocks": ["error", "always"],
+    "@stylistic/space-before-function-paren": [
+      "error",
+      {
+        asyncArrow: "always",
+        anonymous: "never",
+        named: "never",
+      },
+    ],
+    "@stylistic/space-in-parens": ["error", "never"],
+    "@stylistic/space-infix-ops": "error",
+    "@stylistic/space-unary-ops": ["error", { words: true, nonwords: false }],
+    "@stylistic/spaced-comment": [
+      "error",
+      "always",
+      {
+        line: {
+          exceptions: ["-", "+", "*"],
+          markers: ["*package", "!", "/", ",", "="],
+        },
+        block: {
+          balanced: true,
+          exceptions: ["-", "+", "*"],
+          markers: ["*package", "!", "*", ",", ":", "::", "flow-include"],
+        },
+      },
+    ],
+    "@stylistic/switch-colon-spacing": ["error", { after: true, before: false }],
+    "@stylistic/template-curly-spacing": ["error", "never"],
+    "@stylistic/template-tag-spacing": ["error", "never"],
+    "@stylistic/wrap-iife": ["error", "inside", { functionPrototypeMethods: true }],
+    "@stylistic/yield-star-spacing": ["error", "after"],
+
+    ...(typescript === true
+      ? {
+          "@stylistic/member-delimiter-style": "error",
+          "@stylistic/type-annotation-spacing": "error",
+        }
+      : {}),
+  };
+}

--- a/src/configs/stylistic-rules.ts
+++ b/src/configs/stylistic-rules.ts
@@ -33,9 +33,10 @@ export type StylisticCommaDangleOption =
 /**
  * Explicit knobs for each point where two stylistic profiles must diverge.
  *
- * Every knob defaults to the value that reproduces the historical
- * `stylistic()` output exactly; the `"eslint"` formatter backend overrides
- * only the knobs it needs (see `eslint-formatter.ts`).
+ * Default knob values yield the historical `stylistic()` output plus the
+ * adopted modernization extensions (see Task 4 / git log d9531d6, eca0c42,
+ * 649a2b5); the `"eslint"` formatter backend overrides only the knobs it
+ * needs (see `eslint-formatter.ts`).
  */
 export type StylisticRulesProfile = {
   /**
@@ -132,8 +133,11 @@ const DEFAULT_SEMI = true;
  * With default profile values the returned map is rule-for-rule identical to
  * what `stylistic()` emits: it spreads the same `configs.customize(...)` base
  * and then applies the same explicit rule entries on top, so later keys win
- * in exactly the same way. Divergences are expressed exclusively through the
- * `StylisticRulesProfile` knobs.
+ * in exactly the same way. That shared output is the historical `stylistic()`
+ * result plus the adopted modernization extensions (see Task 4 / git log
+ * d9531d6, eca0c42, 649a2b5) — not byte-compat with pre-Task-4 output.
+ * Divergences are expressed exclusively through the `StylisticRulesProfile`
+ * knobs.
  *
  * @param options - Stylistic values, TypeScript flag, and profile knobs.
  * @returns The `@stylistic/*` rule map.

--- a/src/configs/stylistic-rules.ts
+++ b/src/configs/stylistic-rules.ts
@@ -405,6 +405,8 @@ export async function buildStylisticRules(options: Readonly<StylisticRulesOption
       ? {
           "@stylistic/member-delimiter-style": "error",
           "@stylistic/type-annotation-spacing": "error",
+          "@stylistic/type-generic-spacing": "error",
+          "@stylistic/type-named-tuple-spacing": "error",
         }
       : {}),
   };

--- a/src/configs/stylistic-rules.ts
+++ b/src/configs/stylistic-rules.ts
@@ -192,6 +192,12 @@ export async function buildStylisticRules(options: Readonly<StylisticRulesOption
     "@stylistic/comma-spacing": ["error", { before: false, after: true }],
     "@stylistic/comma-style": ["error", "last"],
     "@stylistic/computed-property-spacing": "error",
+    "@stylistic/curly-newline": [
+      "error",
+      {
+        consistent: true,
+      },
+    ],
     "@stylistic/dot-location": ["error", "property"],
     "@stylistic/eol-last": "error",
     "@stylistic/function-call-spacing": ["error", "never"],

--- a/src/configs/stylistic-rules.ts
+++ b/src/configs/stylistic-rules.ts
@@ -175,8 +175,10 @@ export async function buildStylisticRules(options: Readonly<StylisticRulesOption
       "error",
       profile.commaDangle ?? {
         arrays: "only-multiline",
+        dynamicImports: "only-multiline",
         exports: "only-multiline",
         functions: "ignore",
+        importAttributes: "only-multiline",
         imports: "only-multiline",
         objects: "only-multiline",
 

--- a/src/configs/stylistic-rules.ts
+++ b/src/configs/stylistic-rules.ts
@@ -213,6 +213,7 @@ export async function buildStylisticRules(options: Readonly<StylisticRulesOption
               ? {
                   SwitchCase: 1,
                   VariableDeclarator: 1,
+                  assignmentOperator: 1,
                   outerIIFEBody: 1,
                   MemberExpression: 1,
                   FunctionDeclaration: { parameters: 1, body: 1, returnType: 1 },
@@ -233,6 +234,7 @@ export async function buildStylisticRules(options: Readonly<StylisticRulesOption
               : {
                   SwitchCase: 1,
                   VariableDeclarator: 1,
+                  assignmentOperator: 1,
                   outerIIFEBody: 1,
                   MemberExpression: 1,
                   FunctionDeclaration: { parameters: 1, body: 1 },

--- a/src/configs/stylistic.ts
+++ b/src/configs/stylistic.ts
@@ -1,8 +1,9 @@
-import type { StylisticCustomizeOptions } from "@stylistic/eslint-plugin";
 import type { ESLint } from "eslint";
 
 import type { FlatConfigItem, OptionsHasTypeScript, OptionsOverrides, StylisticConfig } from "../types";
 import { loadPackages } from "../utils";
+
+import { buildStylisticRules } from "./stylistic-rules";
 
 /**
  * Default stylistic configuration: indent 2, jsx true, quotes double, semi true, printWidth 120.
@@ -18,8 +19,10 @@ export const StylisticConfigDefaults: Required<StylisticConfig> = {
 /**
  * Generates stylistic ESLint flat config from `@stylistic/eslint-plugin`.
  *
- * Configures indent, quotes, semicolons, and JSX formatting rules.
- * Disables stylistic rules when `stylistic: false`.
+ * Configures indent, quotes, semicolons, and JSX formatting rules via the
+ * shared rule builder (`buildStylisticRules`) also consumed by the `"eslint"`
+ * formatter backend; the default profile reproduces this config's historical
+ * output exactly. Disables stylistic rules when `stylistic: false`.
  *
  * @param options - Stylistic config, overrides, and TypeScript flag.
  * @returns The stylistic flat config items.
@@ -37,15 +40,6 @@ export async function stylistic(
     typeof import("@stylistic/eslint-plugin").default,
   ];
 
-  const config = pluginStylistic.configs.customize({
-    flat: true,
-    indent,
-    jsx,
-    pluginName: "@stylistic",
-    quotes,
-    semi,
-  } as StylisticCustomizeOptions);
-
   return [
     {
       name: "rs:stylistic",
@@ -53,209 +47,7 @@ export async function stylistic(
         "@stylistic": pluginStylistic as ESLint.Plugin,
       },
       rules: {
-        ...config.rules,
-
-        "@stylistic/array-bracket-spacing": ["error", "never"],
-        "@stylistic/arrow-parens": ["error", "always"],
-        "@stylistic/arrow-spacing": ["error", { before: true, after: true }],
-        "@stylistic/block-spacing": ["error", "always"],
-        "@stylistic/brace-style": "error",
-        "@stylistic/comma-dangle": [
-          "error",
-          {
-            arrays: "only-multiline",
-            exports: "only-multiline",
-            functions: "ignore",
-            imports: "only-multiline",
-            objects: "only-multiline",
-
-            ...(typescript && {
-              enums: "only-multiline",
-              generics: "only-multiline",
-              tuples: "only-multiline",
-            }),
-          },
-        ],
-        "@stylistic/comma-spacing": ["error", { before: false, after: true }],
-        "@stylistic/comma-style": ["error", "last"],
-        "@stylistic/computed-property-spacing": "error",
-        "@stylistic/dot-location": ["error", "property"],
-        "@stylistic/eol-last": "error",
-        "@stylistic/function-call-spacing": ["error", "never"],
-        "@stylistic/generator-star-spacing": ["error", "after"],
-        "@stylistic/indent": typescript
-          ? "off"
-          : [
-              "error",
-              indent,
-              {
-                SwitchCase: 1,
-                VariableDeclarator: 1,
-                outerIIFEBody: 1,
-                MemberExpression: 1,
-                FunctionDeclaration: { parameters: 1, body: 1 },
-                FunctionExpression: { parameters: 1, body: 1 },
-                CallExpression: { arguments: 1 },
-                ArrayExpression: 1,
-                ObjectExpression: 1,
-                ImportDeclaration: 1,
-                flatTernaryExpressions: false,
-                ignoreComments: false,
-              },
-            ],
-        "@stylistic/indent-binary-ops": "error",
-        "@stylistic/key-spacing": ["error", { beforeColon: false, afterColon: true }],
-        "@stylistic/keyword-spacing": ["error", { before: true, after: true }],
-        "@stylistic/linebreak-style": ["error", "unix"],
-        "@stylistic/lines-around-comment": [
-          "warn",
-          {
-            beforeBlockComment: true,
-            beforeLineComment: false,
-            afterBlockComment: false,
-            afterLineComment: false,
-            afterHashbangComment: true,
-            allowBlockStart: true,
-            allowBlockEnd: true,
-            allowObjectStart: true,
-            allowObjectEnd: true,
-            allowArrayStart: true,
-            allowArrayEnd: true,
-            allowClassStart: true,
-            allowClassEnd: true,
-
-            ...(typescript && {
-              allowEnumEnd: true,
-              allowEnumStart: true,
-              allowInterfaceEnd: true,
-              allowInterfaceStart: true,
-              allowModuleEnd: true,
-              allowModuleStart: true,
-              allowTypeEnd: true,
-              allowTypeStart: true,
-            }),
-          },
-        ],
-        "@stylistic/lines-between-class-members": [
-          "error",
-          "always",
-          {
-            exceptAfterSingleLine: true,
-            ...(typescript && {
-              exceptAfterOverload: true,
-            }),
-          },
-        ],
-        "@stylistic/max-statements-per-line": ["error", { max: 1 }],
-        "@stylistic/multiline-ternary": ["error", "always-multiline"],
-        "@stylistic/new-parens": "error",
-        "@stylistic/newline-per-chained-call": ["error", { ignoreChainWithDepth: 2 }],
-        "@stylistic/no-extra-parens": ["error", "all", { nestedBinaryExpressions: false }],
-        "@stylistic/no-extra-semi": "error",
-        "@stylistic/no-floating-decimal": "error",
-        "@stylistic/no-mixed-operators": [
-          "error",
-          {
-            groups: [
-              ["+", "-", "*", "/", "%", "**"],
-              ["&", "|", "^", "~", "<<", ">>", ">>>"],
-              ["==", "!=", "===", "!==", ">", ">=", "<", "<="],
-              ["&&", "||"],
-              ["in", "instanceof"],
-            ],
-            allowSamePrecedence: true,
-          },
-        ],
-        "@stylistic/no-mixed-spaces-and-tabs": "error",
-        "@stylistic/no-multi-spaces": ["error", { ignoreEOLComments: true }],
-        "@stylistic/no-multiple-empty-lines": ["error", { max: 1, maxEOF: 1 }],
-        "@stylistic/no-tabs": "error",
-        "@stylistic/no-trailing-spaces": "error",
-        "@stylistic/no-whitespace-before-property": "error",
-        "@stylistic/nonblock-statement-body-position": ["error", "beside", { overrides: {} }],
-        "@stylistic/object-curly-newline": [
-          "error",
-          {
-            ObjectExpression: {
-              minProperties: 3,
-              multiline: true,
-              consistent: true,
-            },
-            ObjectPattern: {
-              minProperties: 3,
-              multiline: true,
-              consistent: true,
-            },
-          },
-        ],
-        "@stylistic/object-curly-spacing": ["error", "always"],
-        "@stylistic/object-property-newline": ["error", { allowAllPropertiesOnSameLine: true }],
-        "@stylistic/one-var-declaration-per-line": ["error", "always"],
-        "@stylistic/operator-linebreak": [
-          "error",
-          "after",
-          {
-            overrides: {
-              // "=": "none",
-              "==": "none",
-              "===": "none",
-              "?": "before",
-              ":": "before",
-              "|": "before",
-            },
-          },
-        ],
-        "@stylistic/padded-blocks": [
-          "error",
-          {
-            blocks: "never",
-            switches: "never",
-            classes: "never",
-          },
-        ],
-        "@stylistic/quote-props": ["error", "consistent-as-needed"],
-        "@stylistic/quotes": ["error", quotes, { avoidEscape: true, allowTemplateLiterals: "never" }],
-        "@stylistic/rest-spread-spacing": ["error", "never"],
-        "@stylistic/semi-spacing": ["error", { before: false, after: true }],
-        "@stylistic/semi-style": ["error", "last"],
-        "@stylistic/semi": ["error", semi ? "always" : "never"],
-        "@stylistic/space-before-blocks": ["error", "always"],
-        "@stylistic/space-before-function-paren": [
-          "error",
-          {
-            asyncArrow: "always",
-            anonymous: "never",
-            named: "never",
-          },
-        ],
-        "@stylistic/space-in-parens": ["error", "never"],
-        "@stylistic/space-infix-ops": "error",
-        "@stylistic/space-unary-ops": ["error", { words: true, nonwords: false }],
-        "@stylistic/spaced-comment": [
-          "error",
-          "always",
-          {
-            line: {
-              exceptions: ["-", "+", "*"],
-              markers: ["*package", "!", "/", ",", "="],
-            },
-            block: {
-              balanced: true,
-              exceptions: ["-", "+", "*"],
-              markers: ["*package", "!", "*", ",", ":", "::", "flow-include"],
-            },
-          },
-        ],
-        "@stylistic/switch-colon-spacing": ["error", { after: true, before: false }],
-        "@stylistic/template-curly-spacing": ["error", "never"],
-        "@stylistic/template-tag-spacing": ["error", "never"],
-        "@stylistic/wrap-iife": ["error", "inside", { functionPrototypeMethods: true }],
-        "@stylistic/yield-star-spacing": ["error", "after"],
-
-        ...(typescript && {
-          "@stylistic/member-delimiter-style": "error",
-          "@stylistic/type-annotation-spacing": "error",
-        }),
+        ...(await buildStylisticRules({ indent, jsx, quotes, semi, typescript })),
 
         ...overrides,
       },

--- a/src/configs/vue.ts
+++ b/src/configs/vue.ts
@@ -244,7 +244,22 @@ export async function vue(
           "stroustrup",
           { allowSingleLine: true },
         ],
-        "vue/comma-dangle": [stylisticEnforcement, "always-multiline"],
+        "vue/comma-dangle": [
+          stylisticEnforcement,
+          {
+            arrays: "only-multiline",
+            exports: "only-multiline",
+            functions: "ignore",
+            imports: "only-multiline",
+            objects: "only-multiline",
+
+            ...(typescript && {
+              enums: "only-multiline",
+              generics: "only-multiline",
+              tuples: "only-multiline",
+            }),
+          },
+        ],
         "vue/comma-spacing": [stylisticEnforcement, { after: true, before: false }],
         "vue/comma-style": [stylisticEnforcement, "last"],
         "vue/html-comment-content-spacing": [
@@ -259,7 +274,19 @@ export async function vue(
         // "vue/object-curly-newline": "off",
         "vue/object-curly-spacing": [stylisticEnforcement, "always"],
         "vue/object-property-newline": [stylisticEnforcement, { allowAllPropertiesOnSameLine: true }],
-        "vue/operator-linebreak": [stylisticEnforcement, "before"],
+        "vue/operator-linebreak": [
+          stylisticEnforcement,
+          "after",
+          {
+            overrides: {
+              "==": "none",
+              "===": "none",
+              "?": "before",
+              ":": "before",
+              "|": "before",
+            },
+          },
+        ],
         "vue/padding-line-between-blocks": [stylisticEnforcement, "always"],
         "vue/quote-props": [stylisticEnforcement, "consistent-as-needed"],
         "vue/space-in-parens": [stylisticEnforcement, "never"],

--- a/src/globs.ts
+++ b/src/globs.ts
@@ -90,6 +90,16 @@ export const GLOB_CTS = "**/?(.)*.cts";
 export const GLOB_STYLE = "**/?(.)*.{c,le,sc,pc,postc}ss";
 
 /**
+ * Indented Sass files (`.sass`).
+ *
+ * Kept as an explicit exclusion for style formatting: neither prettier nor
+ * dprint can parse the indented sass syntax, so these files must stay out of
+ * formatter blocks by design rather than by pattern accident.
+ */
+// cspell:disable-next-line
+export const GLOB_SASS = "**/?(.)*.sass";
+
+/**
  * CSS files.
  */
 export const GLOB_CSS = "**/?(.)*.css";

--- a/src/types.ts
+++ b/src/types.ts
@@ -89,18 +89,24 @@ export type OptionsFormatterCategory = {
   formatter?: FormatterType;
   prettierOptions?: PrettierOptions;
   dprintOptions?: GlobalConfiguration;
+
   /** dprint language plugins for this category. */
   dprintPlugins?: string[];
 };
 
-export type OptionsFormatterCategoryInput =
+export type OptionsFormatterCategoryInput = boolean | FormatterType | OptionsFormatterCategory;
+
+/** Category options where `formatter` may also select the eslint backend. */
+export type OptionsFormatterCategoryEslint = Omit<OptionsFormatterCategory, "formatter"> & {
+  formatter?: FormatterType | "eslint";
+};
+
+/** js/ts additionally accept the eslint backend (string shorthand or object form). */
+export type OptionsFormatterCategoryInputEslint =
   | boolean
   | FormatterType
-  | OptionsFormatterCategory;
-
-/** js/ts additionally accept the eslint backend. */
-export type OptionsFormatterCategoryInputEslint =
-  OptionsFormatterCategoryInput | "eslint";
+  | "eslint"
+  | OptionsFormatterCategoryEslint;
 
 export type OptionsFormattersBase = {
   js?: OptionsFormatterCategoryInputEslint;
@@ -111,10 +117,13 @@ export type OptionsFormattersBase = {
   html?: OptionsFormatterCategoryInput;
   markdown?: OptionsFormatterCategoryInput;
   graphql?: OptionsFormatterCategoryInput;
+
   /** Whether to format dts files. Defaults to `false`. */
   dts?: boolean;
+
   /** Whether to format Tailwind CSS class lists. Defaults to auto-detection. */
   tailwind?: boolean;
+
   /** Whether to format Slidev markdown files. Defaults to auto-detection. */
   slidev?: boolean | ({ files?: string[] } & OptionsFormatterCategory);
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,11 +102,7 @@ export type OptionsFormatterCategoryEslint = Omit<OptionsFormatterCategory, "for
 };
 
 /** js/ts additionally accept the eslint backend (string shorthand or object form). */
-export type OptionsFormatterCategoryInputEslint =
-  | boolean
-  | FormatterType
-  | "eslint"
-  | OptionsFormatterCategoryEslint;
+export type OptionsFormatterCategoryInputEslint = boolean | FormatterType | "eslint" | OptionsFormatterCategoryEslint;
 
 export type OptionsFormattersBase = {
   js?: OptionsFormatterCategoryInputEslint;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,4 @@
+import type { GlobalConfiguration } from "@dprint/formatter";
 import type { StylisticCustomizeOptions } from "@stylistic/eslint-plugin";
 import type { ParserOptions } from "@typescript-eslint/parser";
 import type { TSESLint } from "@typescript-eslint/utils";
@@ -84,6 +85,9 @@ export type OptionsTypescript = OptionsTypeScriptParserOptions &
 
 /**
  * Common formatter options for individual file types.
+ *
+ * When a partial object is passed to the `formatters` option, any unspecified
+ * flag inherits the same defaults as passing `true` (all enabled except `dts`).
  */
 export type OptionsFormattersBase = {
   js?: boolean;
@@ -132,9 +136,9 @@ export type OptionsFormattersDprint = OptionsFormattersBase & {
   formatter: "dprint";
 
   /**
-   * Options for dprint.
+   * Global options for dprint (`lineWidth`, `indentWidth`, `useTabs`, `newLineKind`).
    */
-  dprintOptions?: Record<string, unknown>;
+  dprintOptions?: GlobalConfiguration;
 
   /**
    * dprint language plugins to use when `formatter: "dprint"`.
@@ -148,7 +152,8 @@ export type OptionsFormattersDprint = OptionsFormattersBase & {
  * Per-language formatter enable flags.
  *
  * When `true` is passed to the `formatters` option, all flags default to `true`
- * (except `dts`). Supports Prettier and dprint under the hood.
+ * (except `dts`). Supports Prettier and dprint under the hood. A partial object
+ * inherits the same defaults as `true` for any unspecified flag.
  */
 export type OptionsFormatters = OptionsFormattersPrettier | OptionsFormattersDprint;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,79 +83,48 @@ export type OptionsTypescript = OptionsTypeScriptParserOptions &
   OptionsTypeScriptUnsafeSeverity &
   OptionsTypeScriptShorthands;
 
-/**
- * Common formatter options for individual file types.
- *
- * When a partial object is passed to the `formatters` option, any unspecified
- * flag inherits the same defaults as passing `true` (all enabled except `dts`).
- */
-export type OptionsFormattersBase = {
-  js?: boolean;
-  ts?: boolean;
-  json?: boolean;
-  yaml?: boolean;
-  dts?: boolean;
-  css?: boolean;
-  html?: boolean;
-  markdown?: boolean;
-  graphql?: boolean;
-  tailwind?: boolean;
-  slidev?:
-    | boolean
-    | {
-        files?: string[];
-      };
-};
+export type FormatterType = "prettier" | "dprint";
 
-/**
- * Prettier formatting options.
- */
-export type OptionsFormattersPrettier = OptionsFormattersBase & {
-  /**
-   * Formatter to use: `"prettier"` (default).
-   */
-  formatter?: "prettier";
-
-  /**
-   * Options for Prettier.
-   */
+export type OptionsFormatterCategory = {
+  formatter?: FormatterType;
   prettierOptions?: PrettierOptions;
-
-  dprintOptions?: never;
-
-  dprintPlugins?: never;
-};
-
-/**
- * dprint formatting options.
- */
-export type OptionsFormattersDprint = OptionsFormattersBase & {
-  /**
-   * Formatter to use: `"dprint"`.
-   */
-  formatter: "dprint";
-
-  /**
-   * Global options for dprint (`lineWidth`, `indentWidth`, `useTabs`, `newLineKind`).
-   */
   dprintOptions?: GlobalConfiguration;
-
-  /**
-   * dprint language plugins to use when `formatter: "dprint"`.
-   */
+  /** dprint language plugins for this category. */
   dprintPlugins?: string[];
-
-  prettierOptions?: never;
 };
 
-/**
- * Per-language formatter enable flags.
- *
- * When `true` is passed to the `formatters` option, all flags default to `true`
- * (except `dts`). Supports Prettier and dprint under the hood. A partial object
- * inherits the same defaults as `true` for any unspecified flag.
- */
-export type OptionsFormatters = OptionsFormattersPrettier | OptionsFormattersDprint;
+export type OptionsFormatterCategoryInput =
+  | boolean
+  | FormatterType
+  | OptionsFormatterCategory;
+
+/** js/ts additionally accept the eslint backend. */
+export type OptionsFormatterCategoryInputEslint =
+  OptionsFormatterCategoryInput | "eslint";
+
+export type OptionsFormattersBase = {
+  js?: OptionsFormatterCategoryInputEslint;
+  ts?: OptionsFormatterCategoryInputEslint;
+  json?: OptionsFormatterCategoryInput;
+  yaml?: OptionsFormatterCategoryInput;
+  css?: OptionsFormatterCategoryInput;
+  html?: OptionsFormatterCategoryInput;
+  markdown?: OptionsFormatterCategoryInput;
+  graphql?: OptionsFormatterCategoryInput;
+  /** Whether to format dts files. Defaults to `false`. */
+  dts?: boolean;
+  /** Whether to format Tailwind CSS class lists. Defaults to auto-detection. */
+  tailwind?: boolean;
+  /** Whether to format Slidev markdown files. Defaults to auto-detection. */
+  slidev?: boolean | ({ files?: string[] } & OptionsFormatterCategory);
+};
+
+export type OptionsFormatters = OptionsFormattersBase & {
+  /** Default formatter. `"eslint"` intentionally excluded. */
+  formatter?: FormatterType;
+  prettierOptions?: PrettierOptions;
+  dprintOptions?: GlobalConfiguration;
+};
 
 export type OptionsComponentExts = {
   /**
@@ -506,6 +475,13 @@ export type OptionsConfig = {
    * Use external formatters to format files.
    *
    * When set to `true`, it will enable all formatters.
+   *
+   * Each file category (`js`, `ts`, `json`, `yaml`, `css`, `html`, `markdown`,
+   * `graphql`) accepts `true`, `false`, a formatter name (`"prettier"`,
+   * `"dprint"`, or `"eslint"` for `js`/`ts` only), or an options object
+   * (`formatter`, `prettierOptions`, `dprintOptions`, `dprintPlugins`) to
+   * select its own backend. Categories without an explicit formatter inherit
+   * the top-level `formatter` (default `"prettier"`).
    */
   formatters?: boolean | OptionsFormatters;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,6 +51,14 @@ export const parserPlain: Linter.Parser = {
 };
 
 /**
+ * Memoized package load promises, keyed by package id.
+ *
+ * Guarantees a single module instance per specifier, even when `loadPackages`
+ * is called concurrently with overlapping package lists.
+ */
+const mut_packageLoadPromises = new Map<string, Promise<unknown>>();
+
+/**
  * Load and interop-default a list of packages, prompting to install any that are missing.
  *
  * @param packageIds - The packages to load
@@ -68,8 +76,21 @@ export async function loadPackages<T extends ReadonlyArray<string>>(
     await installPackages(missing);
   }
 
+  const mut_promises = packageIds.map((id) => {
+    let mut_promise = mut_packageLoadPromises.get(id);
+    if (mut_promise === undefined) {
+      mut_promise = interopDefault(import(id));
+      mut_packageLoadPromises.set(id, mut_promise);
+      // Evict rejected loads so a later call can retry the import.
+      mut_promise.catch(() => {
+        mut_packageLoadPromises.delete(id);
+      });
+    }
+    return mut_promise;
+  });
+
   // eslint-disable-next-line ts/no-explicit-any, ts/no-unsafe-return
-  return Promise.all(packageIds.map((id) => interopDefault(import(id)))) as any;
+  return Promise.all(mut_promises) as any;
 }
 
 /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
 import fs from "node:fs/promises";
 import path from "node:path";
 
@@ -6,7 +7,7 @@ import type { ESLint, Linter } from "eslint";
 import type { Awaitable } from "eslint-flat-config-utils";
 import { isPackageExists } from "local-pkg";
 
-import type { FlatConfigItem } from "./types";
+import type { FlatConfigItem, StylisticConfig } from "./types";
 
 /**
  * Combine array and non-array configs into a single array.
@@ -242,6 +243,158 @@ export async function detectPnpmCatalog(projectRoot: string): Promise<boolean> {
   } catch {}
 
   return false;
+}
+
+/**
+ * Indent sizes honored when deriving the stylistic indent from `.editorconfig`.
+ */
+const EDITORCONFIG_INDENT_SIZES: ReadonlySet<number> = new Set([2, 4, 8]);
+
+/**
+ * Extension tokens of `.editorconfig` section selectors that target JavaScript or TypeScript files.
+ */
+const EDITORCONFIG_SCRIPT_SECTION_TOKEN = /^[cm]?[jt]sx?$/u;
+
+/**
+ * Whether an `.editorconfig` section selector applies to JavaScript/TypeScript files.
+ *
+ * Accepts the universal `*` selector and selectors whose extension tokens are
+ * JS/TS variants (`*.js`, `*.ts`, `*.{js,jsx,ts,tsx}`, ...).
+ *
+ * @param section - The section selector without its surrounding brackets
+ * @returns `true` when the section targets JavaScript/TypeScript files
+ */
+function editorConfigSectionAppliesToScripts(section: string): boolean {
+  return (
+    section === "*" || section.split(/[,.{}]/u).some((token) => EDITORCONFIG_SCRIPT_SECTION_TOKEN.test(token.trim()))
+  );
+}
+
+/**
+ * Extract the JS/TS indentation setting from raw `.editorconfig` contents.
+ *
+ * Minimal INI handling: CRLF-normalized lines, `#`/`;` comments stripped,
+ * lowercased keys/values, and only sections applying to JS/TS files (the
+ * universal `*` plus js/ts variants) consulted. Later matching sections win,
+ * mirroring editorconfig semantics.
+ *
+ * @param content - Raw `.editorconfig` contents
+ * @returns The derived indent value, or `undefined` when none is specified
+ */
+function parseEditorConfigIndent(content: string): StylisticConfig["indent"] {
+  let mut_indentStyle: string | undefined;
+  let mut_indentSize: string | undefined;
+  let mut_tabWidth: string | undefined;
+  let mut_currentSection: string | undefined;
+
+  /* eslint-disable functional/no-loop-statements -- line-by-line INI parsing requires iteration */
+  for (const rawLine of content.replaceAll("\r\n", "\n").split("\n")) {
+    const line = rawLine.split("#", 1)[0]?.split(";", 1)[0]?.trim() ?? "";
+    if (line.length === 0) {
+      continue;
+    }
+
+    if (line.startsWith("[") && line.endsWith("]")) {
+      mut_currentSection = line.slice(1, -1);
+      continue;
+    }
+
+    const separatorIndex = line.indexOf("=");
+    if (
+      separatorIndex === -1 ||
+      mut_currentSection === undefined ||
+      !editorConfigSectionAppliesToScripts(mut_currentSection)
+    ) {
+      continue;
+    }
+
+    const key = line.slice(0, separatorIndex).trim().toLowerCase();
+    const value = line
+      .slice(separatorIndex + 1)
+      .trim()
+      .toLowerCase();
+
+    switch (key) {
+      case "indent_style": {
+        mut_indentStyle = value;
+        break;
+      }
+      case "indent_size": {
+        mut_indentSize = value;
+        break;
+      }
+      case "tab_width": {
+        mut_tabWidth = value;
+        break;
+      }
+      // No default: keys irrelevant to indent derivation are ignored.
+    }
+  }
+  /* eslint-enable functional/no-loop-statements -- line-by-line INI parsing requires iteration */
+
+  if (mut_indentStyle === "tab") {
+    return "tab";
+  }
+
+  // `indent_size = tab` defers to `tab_width`, mirroring editorconfig semantics.
+  /* eslint-disable functional/no-loop-statements -- candidate precedence check requires iteration */
+  for (const size of [mut_indentSize, mut_tabWidth]) {
+    const parsed = Number(size);
+    if (EDITORCONFIG_INDENT_SIZES.has(parsed)) {
+      return parsed;
+    }
+  }
+  /* eslint-enable functional/no-loop-statements -- candidate precedence check requires iteration */
+
+  return undefined;
+}
+
+/**
+ * Derive the stylistic indent from the project's `.editorconfig`.
+ *
+ * Walks up from `projectRoot` to the nearest `.editorconfig` — stopping at one
+ * declaring `root = true` without any indent setting — and reads its JS/TS
+ * indentation: `"tab"` for `indent_style = tab`, otherwise `indent_size` or
+ * `tab_width` when set to 2, 4, or 8. Never throws; missing or malformed
+ * files yield `undefined`.
+ *
+ * @param projectRoot - Root directory of the project
+ * @returns The derived indent value, or `undefined` when undetectable
+ */
+export function readEditorConfigIndent(projectRoot: string): StylisticConfig["indent"] {
+  try {
+    let mut_dir = path.resolve(projectRoot);
+
+    /* eslint-disable functional/no-loop-statements -- directory walk requires iteration */
+    while (true) {
+      const editorConfigPath = path.join(mut_dir, ".editorconfig");
+
+      // eslint-disable-next-line node/no-sync -- stylistic options resolve synchronously during assembly
+      if (existsSync(editorConfigPath)) {
+        // eslint-disable-next-line node/no-sync -- stylistic options resolve synchronously during assembly
+        const content = readFileSync(editorConfigPath, "utf8");
+        const indent = parseEditorConfigIndent(content);
+
+        if (indent !== undefined) {
+          return indent;
+        }
+
+        // A root-declaring file ends the search even when it sets no indent.
+        if (/^root\s*=\s*true\s*$/mu.test(content)) {
+          return undefined;
+        }
+      }
+
+      const parent = path.dirname(mut_dir);
+      if (parent === mut_dir) {
+        return undefined;
+      }
+      mut_dir = parent;
+    }
+    /* eslint-enable functional/no-loop-statements -- directory walk requires iteration */
+  } catch {
+    return undefined;
+  }
 }
 
 const IGNORED_TSCONFIG_DIRS = new Set([


### PR DESCRIPTION
- **refactor(formatters): type dprint options and correct placement/defaults**
- **chore: add cross-repo smoke test script**
- **feat!: per-category formatter selection**
- **feat: eslint formatting backend**
- **refactor: unify stylistic rule sources**
- **docs: document stylistic rule-source unification**
- **feat: adopt @stylistic/curly-newline**
- **feat: adopt ts-native spacing rules**
- **feat: comma-dangle coverage for import attributes and dynamic imports**
- **feat: indent returnType and assignmentOperator options**
- **docs: note list-style migration deferred to @stylistic v6**
- **docs: add disabled-rule audit (Task 5)**
- **style: pipe-align rule-audit tables**
- **feat: format css-family style blocks in Vue SFCs**
- **fix(formatters): reject unknown formatter values at runtime**
- **test: add on-demand vue SFC style-block probe**
- **docs: note vue-style virtual-glob edge case**
- **docs(assembly): spell out suppression ignores semantics**
- **fix: require @stylistic/eslint-plugin >= 5.10 for adopted rule surfaces**
- **docs: correct builder byte-compat claims post-Task-4**
- **fix(formatters): treat null category as unset for enablement**
- **chore(smoke): derive config repo path from script location**
